### PR TITLE
Add tests, njit add_current

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 dist: xenial
+cache: pip
 python:
 - '3.6'
 - '3.7'

--- a/tests/test_strax_interface.py
+++ b/tests/test_strax_interface.py
@@ -1,0 +1,21 @@
+import strax
+import straxen
+import wfsim
+
+strax.mailbox.Mailbox.DEFAULT_TIMEOUT = 20
+
+
+def test_sim():
+    # Just some id from post-SR1, so the corrections work
+    run_id = '180519_1902'
+
+    st = strax.Context(
+        register=wfsim.RawRecordsFromFax,
+        config=dict(nevents=4),
+        **straxen.contexts.common_opts)
+
+    # Call for event_info so it immediately get processed as well
+    peaks = st.get_array(run_id, 'peaks')
+
+    assert len(peaks) > 0
+    assert peaks['area'].sum() > 0

--- a/tests/test_strax_interface.py
+++ b/tests/test_strax_interface.py
@@ -10,12 +10,12 @@ def test_sim():
     run_id = '180519_1902'
 
     st = strax.Context(
+        storage=[],
         register=wfsim.RawRecordsFromFax,
         config=dict(nevents=4),
         **straxen.contexts.common_opts)
 
-    # Call for event_info so it immediately get processed as well
-    peaks = st.get_array(run_id, 'peaks')
+    rr = st.get_array(run_id, 'raw_records')
 
-    assert len(peaks) > 0
-    assert peaks['area'].sum() > 0
+    assert len(rr) > 0
+    assert rr['data'].sum() > 0

--- a/tests/test_strax_interface.py
+++ b/tests/test_strax_interface.py
@@ -1,3 +1,5 @@
+import tempfile
+
 import strax
 import straxen
 import wfsim
@@ -8,14 +10,14 @@ strax.mailbox.Mailbox.DEFAULT_TIMEOUT = 20
 def test_sim():
     # Just some id from post-SR1, so the corrections work
     run_id = '180519_1902'
+    with tempfile.TemporaryDirectory() as tempdir:
+        st = strax.Context(
+            storage=tempdir,
+            register=wfsim.RawRecordsFromFax,
+            config=dict(nevents=4),
+            **straxen.contexts.common_opts)
 
-    st = strax.Context(
-        storage=[],
-        register=wfsim.RawRecordsFromFax,
-        config=dict(nevents=4),
-        **straxen.contexts.common_opts)
-
-    rr = st.get_array(run_id, 'raw_records')
+        rr = st.get_array(run_id, 'raw_records')
 
     assert len(rr) > 0
     assert rr['data'].sum() > 0


### PR DESCRIPTION
This will:
  * Add a unit test that verifies the simulator does not crash.
  * Add a check in the strax interface that chunks of raw_records passed to straxen are sorted by time and sufficiently well-spaced. 
    * Strax, or rather the low-level processing algorithms in straxen, require(s) this. The DAQReader does work for to ensure it, but here we're not reading from the DAQ.
    * If you pass unsorted or (nearly) overlapping chunks of records to strax it can cause a hang until the mailbox timeouts expire (I'm not exactly sure why). 
    * I did not want to dig too deeply to figure out why we got non-sorted or overlapping chunks in some conditions, so I just added a check and made it throw an exception if we see the problem. I hope a future fix would solve the problem and remove the check.
  * Replace the `guvectorize`d `add_current` with a `njit`ed explicit for loop. This gives about a 30% speedup to the simulator (tested by simulating 1000-electron S2s). 
    * The problem was that numba couldn't figure out the types of the globals that the guvectorized function used, and thus used its slower object mode rather than the main nopython mode.
    * I didn't actually intend to do any optimization, but a nice warning message about this issue from numba 0.45 pointed out the problem very specifically. Apparently numba is retiring object mode; in the future numba will just give an error in cases like this.