### PR TITLE
Fixes selftrigger mistake

### DIFF
--- a/wfsim/strax_interface.py
+++ b/wfsim/strax_interface.py
@@ -185,8 +185,11 @@ class ChunkRawRecords(object):
     strax.Option('fax_config', 
                  default='https://raw.githubusercontent.com/XENONnT/'
                  'strax_auxiliary_files/master/fax_files/fax_config.json'),
-    strax.Option('samples_to_store_before', default = 2),
-    strax.Option('samples_to_store_after', default = 20),
+    strax.Option('samples_to_store_before',
+                 default=2),
+    strax.Option('samples_to_store_after',
+                 default=20),
+    strax.Option('trigger_window', default = 50),
     strax.Option('zle_threshold',default = 0))
 class FaxSimulatorPlugin(strax.Plugin):
     depends_on = tuple()


### PR DESCRIPTION
This pull request fixes a a bug in the self triggering mechanism. The self triggering window of the digitizer was confused with the length of the PMT response. This caused the simulated pulses to appear in the region Strax uses to calculate the baseline leading to negative areas.