### PR TITLE
Update G4 and PAX interface

### DIFF
--- a/wfsim/__init__.py
+++ b/wfsim/__init__.py
@@ -2,3 +2,4 @@ __version__ = '0.0.3'
 
 from .core import *
 from .strax_interface import *
+from .pax_interface import *

--- a/wfsim/core.py
+++ b/wfsim/core.py
@@ -324,6 +324,10 @@ class S2(Pulse):
         electron_lifetime_correction = np.exp(- 1 * self.drift_time_mean /
                                               self.config['electron_lifetime_liquid'])
         cy = self.config['electron_extraction_yield'] * electron_lifetime_correction
+        
+        #why are there cy greater than 1? We should check this
+        cy = np.clip(cy, a_min = 0, a_max = 1)
+
         n_electron = np.random.binomial(n=list(n_electron), p=cy)
 
         # Second generate photon timing and channel

--- a/wfsim/pax_interface.py
+++ b/wfsim/pax_interface.py
@@ -92,7 +92,7 @@ class PaxEventSimulator(object):
 
         if self.config['fax_file']:
             if self.config['fax_file'][-5:] == '.root':
-                self.instructions = read_g4(c['fax_file'])
+                self.instructions = read_g4(self.config['fax_file'])
                 self.config['nevents'] = np.max(self.instructions['event_number'])
             else:
                 self.instructions = instruction_from_csv(self.config['fax_file'])
@@ -135,7 +135,8 @@ class PaxEventSimulator(object):
             
             self.output_dir = os.path.join(self.config['output_name'], 
                 '%s_MC_%d' % (self.config['experiment'], self.config['run_number']))
-            if not os.path.exists(self.output_dir): os.mkdir(self.output_dir)
+            #if not os.path.exists(self.output_dir): os.mkdir(self.output_dir)
+            os.makedirs(self.output_dir, exist_ok=True)
             
             # Start the temporary file. Events will first be written here, until events_per_file is reached
             self.tempfile = os.path.join(self.output_dir, 'temp.' + self.file_extension)
@@ -162,7 +163,8 @@ class PaxEventSimulator(object):
         def close_current_file(self):
             """Closes the currently open file, if there is one. Also handles temporary file renaming. """
             if self.last_event_written is None:
-                self.log.info("You didn't write any events... Did you crash pax?")
+                #self.log.info("You didn't write any events... Did you crash pax?")
+                print("You didn't write any events... Did you crash pax?")
                 return
 
             self.current_file.close()


### PR DESCRIPTION
New function to read Geant4 files. We are now using the individual positions of each interactions and the corresponding energy depositions. The event number is taken from the Geant4 root file as well. The events are now separated by a constant time difference. I think this can be changed in the future to be more efficient. 

Things to do next:
-  get the recoil type (ER, NR) from the interaction
-  get the interacting particle for NEST from the Geant4 file
- do we need some clustering like in nSort?
- Why are there cy > 1 values in core.py?
