### PR TITLE
Redesign chunk mechanism

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open('HISTORY.md') as file:
 
 setuptools.setup(
     name='wfsim',
-    version='0.0.2',
+    version='0.0.3',
     description='XENONnT Waveform simulator',
     author='Wfsim contributors, the XENON collaboration',
     url='https://github.com/XENONnT/wfsim',

--- a/wfsim/core.py
+++ b/wfsim/core.py
@@ -709,7 +709,7 @@ class RawData(object):
         self.pulses['pmt_ap'](self.pulses[ptype])
         
         for pt in [ptype, 'pmt_ap']:
-            _pulses = getattr(self.pulses[ptype], '_pulses')
+            _pulses = getattr(self.pulses[pt], '_pulses')
             if len(_pulses) > 0:
                 self._pulses_cache += _pulses
                 self.last_pulse_end_time = max(self.last_pulse_end_time,
@@ -725,7 +725,9 @@ class RawData(object):
         """
         Superimpose pulses (wfsim definition) into WFs w/ dynamic range truncation
         """
-        if len(self._pulses_cache) > 0:
+        if len(self._pulses_cache) == 0:
+            self._raw_data = []
+        else:
             self.current_2_adc = self.config['pmt_circuit_load_resistor'] \
                 * self.config['external_amplification'] \
                 / (self.config['digitizer_voltage_range'] / 2 ** (self.config['digitizer_bits']))
@@ -761,7 +763,7 @@ class RawData(object):
         """
         # Ask for memory allocation just once
         if 'zle_intervals_buffer' not in self.__dict__:
-            self.zle_intervals_buffer = -1 * np.ones((50000, 2), dtype=np.int64)
+            self.zle_intervals_buffer = -1 * np.ones((50000, 2), dtype=np.int64)            
         
         for ix, data in enumerate(self._raw_data):
             # For simulated data taking reference baseline as baseline

--- a/wfsim/pax_interface.py
+++ b/wfsim/pax_interface.py
@@ -137,7 +137,6 @@ class PaxEventSimulator(object):
             
             self.output_dir = os.path.join(self.config['output_name'], 
                 '%s_MC_%d' % (self.config['experiment'], self.config['run_number']))
-            #if not os.path.exists(self.output_dir): os.mkdir(self.output_dir)
             os.makedirs(self.output_dir, exist_ok=True)
             
             # Start the temporary file. Events will first be written here, until events_per_file is reached
@@ -165,7 +164,6 @@ class PaxEventSimulator(object):
         def close_current_file(self):
             """Closes the currently open file, if there is one. Also handles temporary file renaming. """
             if self.last_event_written is None:
-                #self.log.info("You didn't write any events... Did you crash pax?")
                 print("You didn't write any events... Did you crash pax?")
                 return
 

--- a/wfsim/strax_interface.py
+++ b/wfsim/strax_interface.py
@@ -19,7 +19,9 @@ instruction_dtype = [('event_number', np.int), ('type', np.int), ('t', np.int),
     ('x', np.float32), ('y', np.float32), ('z', np.float32), 
     ('amp', np.int), ('recoil', '<U2')]
 
-truth_extra_dtype = [('n_photon', np.float), ('n_electron', np.float),
+truth_extra_dtype = [
+    ('n_electron', np.float),
+    ('n_photon', np.float), ('n_photon_bottom', np.float),
     ('t_first_photon', np.float), ('t_last_photon', np.float), 
     ('t_mean_photon', np.float), ('t_sigma_photon', np.float), 
     ('t_first_electron', np.float), ('t_last_electron', np.float), 
@@ -142,33 +144,30 @@ class ChunkRawRecords(object):
         samples_per_record = strax.DEFAULT_RECORD_LENGTH
         buffer_length = len(self.record_buffer)
         dt = self.config['sample_duration']
+        rext = self.config['right_raw_extension']
+        cksz = self.config['chunk_size'] * 1e9
+        
+        self.record_j = 0 # Buffer fill level
+        self.chunk_time = np.min(instructions['t']) + cksz # Starting chunk
 
-        chunk_i = record_j = 0 # Indices of chunk(event), record buffer
         for channel, left, right, data in self.rawdata(instructions, self.truth_buffer):
             pulse_length = right - left + 1
             records_needed = int(np.ceil(pulse_length / samples_per_record))
-
-            # Currently chunk is decided by instruction using event_number
-            # TODO: mimic daq strax insertor chunking
-            chunk_i =0
-            if instructions['event_number'][self.rawdata.instruction_index] > chunk_i:
-                yield self.final_results(record_j)
-                record_j = 0 # Reset record buffer
-                self.truth_buffer['fill'] = np.zeros_like(len(self.truth_buffer)) # Reset truth buffer
-                chunk_i = instructions['event_number'][self.rawdata.instruction_index]
-
-            if record_j + records_needed > buffer_length:
-                log.warning('Chunck size too large, insufficient record buffer')
-                yield self.final_results(record_j)
-                record_j = 0
-                self.truth_buffer['fill'] = np.zeros_like(len(self.truth_buffer))
             
-            if record_j + records_needed > buffer_length:
+            if left * 10 > self.chunk_time + 2 * rext:    
+                yield self.final_results()
+                self.chunk_time += cksz
+
+            if self.record_j + records_needed > buffer_length:
+                log.warning('Chunck size too large, insufficient record buffer')
+                yield self.final_results()
+
+            if self.record_j + records_needed > buffer_length:
                 log.Warning('Pulse length too large, insufficient record buffer, skipping pulse')
                 continue
 
             # WARNING baseline and area fields are zeros before finish_results
-            s = slice(record_j, record_j + records_needed)
+            s = slice(self.record_j, self.record_j + records_needed)
             self.record_buffer[s]['channel'] = channel
             self.record_buffer[s]['dt'] = dt
             self.record_buffer[s]['time'] = dt * (left + samples_per_record * np.arange(records_needed))
@@ -179,23 +178,34 @@ class ChunkRawRecords(object):
             self.record_buffer[s]['data'] = np.pad(data, 
                 (0, records_needed * samples_per_record - pulse_length), 'constant').reshape((-1, samples_per_record))
 
-            record_j += records_needed
+            self.record_j += records_needed
 
-        yield self.final_results(record_j)
+        yield self.final_results()
 
-    def final_results(self, record_j):
-        records = self.record_buffer[:record_j] # Copy the records from buffer
+    def final_results(self):
+        records = self.record_buffer[:self.record_j] # Copy the records from buffer
         records = strax.sort_by_time(records) # Must keep this for sorted output
+
+        mask = records['time'] >= self.chunk_time
+        self.record_buffer[:np.sum(mask)] = records[mask]
+        self.record_j = np.sum(mask)
+        records = records[~mask]
         strax.baseline(records)
         strax.integrate(records)
 
-        _truth = self.truth_buffer[self.truth_buffer['fill']]
-        # Return truth without 'fill' field
-        truth = np.zeros(len(_truth), dtype=instruction_dtype + truth_extra_dtype)
-        for name in truth.dtype.names:
-            truth[name] = _truth[name]
+        truth = self.truth_buffer[self.truth_buffer['fill']]
+        # truth = strax.sort_by_time(truth) # Unsupported
 
-        return dict(raw_records=records, truth=truth)
+        mask = truth['t_first_photon'] >= self.chunk_time
+        self.truth_buffer[:np.sum(mask)] = truth[mask]
+        self.truth_buffer['fill'][np.sum(mask):] = False
+
+        # Return truth without 'fill' field
+        _truth = np.zeros(len(truth), dtype=instruction_dtype + truth_extra_dtype)
+        for name in _truth.dtype.names:
+            _truth[name] = truth[name]
+
+        return dict(raw_records=records, truth=_truth)
 
     def source_finished(self):
         return self.rawdata.source_finished
@@ -219,6 +229,7 @@ class ChunkRawRecords(object):
                  default=2),
     strax.Option('samples_to_store_after',
                  default=20),
+    strax.Option('right_raw_extension', default=10000),
     strax.Option('trigger_window', default=50),
     strax.Option('zle_threshold', default=0))
 class FaxSimulatorPlugin(strax.Plugin):
@@ -302,5 +313,5 @@ class RawRecordsFromFax(FaxSimulatorPlugin):
             result = next(self.sim_iter)
         except StopIteration:
             raise RuntimeError("Bug in chunk count computation")
-        self._sort_check(result['raw_records'])
+        # self._sort_check(result['raw_records'])
         return result

--- a/wfsim/strax_interface.py
+++ b/wfsim/strax_interface.py
@@ -183,16 +183,16 @@ class ChunkRawRecords(object):
 
     def final_results(self):
         records = self.record_buffer[:self.blevel] # No copying the records from buffer
-        mask = records['time'] < self.chunk_time
-        records = records[mask]
+        maska = records['time'] < self.chunk_time
+        records = records[maska]
 
         records = strax.sort_by_time(records) # Do NOT remove this line
         strax.baseline(records)
         strax.integrate(records)
 
-        mask = self.truth_buffer['fill'] & (self.truth_buffer['t_first_photon'] < self.chunk_time)
-        truth = self.truth_buffer[mask]
-        self.truth_buffer[mask]['fill'] = False
+        maskb = self.truth_buffer['fill'] & (self.truth_buffer['t_first_photon'] < self.chunk_time)
+        truth = self.truth_buffer[maskb]
+        self.truth_buffer[maskb]['fill'] = False
 
         truth.sort(order='t_first_photon')
         # Return truth without 'fill' field
@@ -202,8 +202,8 @@ class ChunkRawRecords(object):
 
         yield dict(raw_records=records, truth=_truth)
         
-        self.record_buffer[:np.sum(~mask)] = records[~mask]
-        self.blevel = np.sum(~mask)
+        self.record_buffer[:np.sum(~maska)] = self.record_buffer[:self.blevel][~maska]
+        self.blevel = np.sum(~maska)
 
     def source_finished(self):
         return self.rawdata.source_finished


### PR DESCRIPTION
Event_number in instruction was used as a temporary solution to chunking, however, event_number  is intended to be reserved for other purposes. While chunk should be done automatically by 'time'.

This pr also try to solve 
1) Crash due to unable to yield when event_rate is set above 100 Hz and cut off time set > 0.1 seconds. 
2) Long term effect e.g. photo ionization (PI) electrons are saved into instruction buffer as well as the truth.
3) Double photon electron is propagated to the truth output as well.

Immediate effects are:
1) Instruction input can be unsorted now
2) Must specify chunk_size in config, (especially when not using build-in random instruction)
3) Running might be just a tiny bit slower.

For the future:
1) Delay coincidence can be implemented very easily.
2) Long term single electron effect can be added the same way as PI.