### PR TITLE
Truth writing fixes

### DIFF
--- a/notebooks/Fax_Tutorial.ipynb
+++ b/notebooks/Fax_Tutorial.ipynb
@@ -19,7 +19,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -51,14 +51,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "url_base = 'https://raw.githubusercontent.com/XENONnT/strax_auxiliary_files/master/fax_files/'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "st = strax.Context(\n",
     "    register=wfsim.RawRecordsFromFax,\n",
     "    config=dict(detector=\"XENONnT\",\n",
-    "               fax_config = '/dali/lgrandi/pgaemers/fax_files/fax_config_nt.json',\n",
+    "                fax_config=url_base + 'fax_config_nt.json'),\n",
     "    **straxen.contexts.common_opts)"
    ]
   },
@@ -72,7 +81,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -90,13 +99,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "st.set_config(dict(to_pe_file='/dali/lgrandi/pgaemers/fax_files/to_pe_nt.npy',\n",
-    "                   nn_architecture ='/dali/lgrandi/pgaemers/fax_files/mlp_model.json',\n",
-    "                   nn_weights = '/dali/lgrandi/pgaemers/fax_files/mlp_model.h5'))"
+    "st.set_config(dict(to_pe_file=url_base + 'to_pe_nt.npy',\n",
+    "                   nn_architecture = url_base + 'mlp_model.json',\n",
+    "                   nn_weights = url_base +  'mlp_model.h5'))"
    ]
   },
   {
@@ -109,7 +118,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -125,7 +134,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -169,7 +178,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -278,22 +287,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Removing data in ./strax_data/1-n_competing-ztzgpdn2w3 to overwrite\n",
-      "Removing data in ./strax_data/1-events-q6uc2rbkb3 to overwrite\n",
-      "Removing data in ./strax_data/1-event_basics-4xtmj57sgz to overwrite\n",
-      "Removing data in ./strax_data/1-corrected_areas-l3p6xdpdhf to overwrite\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Remove any previously simulated data, if such exists\n",
     "# !rm -r strax_data\n",
@@ -324,7 +322,7 @@
     "plt.fill_between(\n",
     "    ns,\n",
     "    np.percentile(r['data'], 25, axis=0),\n",
-    "    np.percentile(r['data'], 75, axis=0), \n",
+    "    np.percentile(r['data'], 75, axis=0),\n",
     "    step='mid', alpha=0.3, linewidth=0)\n",
     "plt.xlabel(\"Sample in record\")\n",
     "plt.ylabel(\"Amplitude (ADCc)\")\n",
@@ -498,7 +496,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.6.9"
   }
  },
  "nbformat": 4,

--- a/notebooks/test_simulator.ipynb
+++ b/notebooks/test_simulator.ipynb
@@ -22,7 +22,7 @@
    "outputs": [],
    "source": [
     "# Just some id from post-SR1, so the corrections work\n",
-    "run_id = '180519_1902'\n"
+    "run_id = '180519_1902'"
    ]
   },
   {
@@ -40,7 +40,6 @@
    "source": [
     "st = strax.Context(\n",
     "    register=wfsim.RawRecordsFromFax,\n",
-    "    config=dict(nevents=4),\n",
     "    **straxen.contexts.common_opts)"
    ]
   },
@@ -60,43 +59,6 @@
     "st.make(run_id, 'event_info')\n",
     "\n",
     "st.waveform_display(run_id)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Peak simulator"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "st = strax.Context(\n",
-    "    register=wfsim.PeaksFromFax,\n",
-    "    config=dict(nevents=4),\n",
-    "    **straxen.contexts.common_opts)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Remove any previously simulated data, if such exists\n",
-    "!rm -r strax_data\n",
-    "\n",
-    "st.set_config(dict(nevents=1))\n",
-    "\n",
-    "peaks = st.get_array(run_id, 'peaks')\n",
-    "\n",
-    "for p in peaks:\n",
-    "    plt.plot(p['data'])\n",
-    "    plt.show()"
    ]
   }
  ],

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-straxen
+git+git://github.com/XENONnT/straxen
 uproot
 nestpy

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,9 @@
 import setuptools
 
 with open('requirements.txt') as f:
-    requires = f.read().splitlines()
+    requires = [
+        r.split('/')[-1] if r.startswith('git+') else r
+        for r in f.read().splitlines()]
 
 with open('README.md') as file:
     readme = file.read()

--- a/tests/test_wfsim.py
+++ b/tests/test_wfsim.py
@@ -6,20 +6,53 @@ import wfsim
 
 strax.mailbox.Mailbox.DEFAULT_TIMEOUT = 60
 
+# Just some id from post-SR1, so the corrections work
+run_id = '180519_1902'
 
-def test_sim():
-    # Just some id from post-SR1, so the corrections work
-    run_id = '180519_1902'
+
+def test_sim_nt():
     with tempfile.TemporaryDirectory() as tempdir:
         st = strax.Context(
             storage=tempdir,
             register=wfsim.RawRecordsFromFax,
-            config=dict(dict(nchunk=1, event_rate=1, chunk_size=10)),
+            config=dict(nchunk=1, event_rate=1, chunk_size=10,
+                        detector='XENONnT',
+                        fax_config='https://raw.githubusercontent.com/XENONnT/'
+                                   'strax_auxiliary_files/master/fax_files/fax_config_nt.json'),
             **straxen.contexts.common_opts)
 
         rr = st.get_array(run_id, 'raw_records')
         p = st.get_array(run_id, 'peaks')
+        _sanity_check(rr, p)
 
-    assert len(rr) > 0
-    assert rr['data'].sum() > 0
-    assert p['data'].sum() > 0
+
+def test_sim():
+    with tempfile.TemporaryDirectory() as tempdir:
+        st = strax.Context(
+            storage=tempdir,
+            register=wfsim.RawRecordsFromFax,
+            config=dict(nchunk=1, event_rate=1, chunk_size=10,
+                        detector='XENON1T'),
+            **straxen.contexts.common_opts)
+
+        rr = st.get_array(run_id, 'raw_records')
+        p = st.get_array(run_id, 'peaks')
+        _sanity_check(rr, p)
+
+        # Test simulation config override
+        # We'll set the extraction yield to 0, then check that the
+        # total simulated area is much less than before
+        # TODO: it would be nicer to do this without random instructions...
+        st.set_config(dict(fax_config_override=dict(
+            electron_extraction_yield=0)))
+        rr2 = st.get_array(run_id, 'raw_records')
+        p2 = st.get_array(run_id, 'peaks')
+        _sanity_check(rr2, p2)
+
+        assert p2['area'].sum() < 0.1 * p['area'].sum()
+
+
+def _sanity_check(raw_records, peaks):
+    assert len(raw_records) > 0
+    assert raw_records['data'].sum() > 0
+    assert peaks['data'].sum() > 0

--- a/wfsim/core.py
+++ b/wfsim/core.py
@@ -824,7 +824,7 @@ class RawData(object):
         for ix, data in enumerate(self._raw_data):
             # For simulated data taking reference baseline as baseline
             # Operating directly on digitized downward waveform        
-            if ix in self.config.get('special_thresholds', {}):
+            if str(ix) in self.config.get('special_thresholds', {}):
                 threshold = self.config['digitizer_reference_baseline'] \
                     - self.config['special_thresholds'][str(ix)] - 1
             else:

--- a/wfsim/core.py
+++ b/wfsim/core.py
@@ -862,7 +862,7 @@ class RawData(object):
 
         for quantum in 'photon', 'electron':
             times = getattr(pulse, f'_{quantum}_timings', [])
-            if times:
+            if len(times):
                 tb[f'n_{quantum}'] = len(times)
                 tb[f't_mean_{quantum}'] = np.mean(times)
                 tb[f't_first_{quantum}'] = np.min(times)

--- a/wfsim/core.py
+++ b/wfsim/core.py
@@ -870,6 +870,9 @@ class RawData(object):
                 tb[f't_sigma_{quantum}'] = np.std(times)
             else:
                 # Peak does not have photons / electrons
+                # zero-photon afterpulses can be removed from truth info
+                if peak_type not in ['s1', 's2'] and quantum == 'photon':
+                    return
                 tb[f'n_{quantum}'] = 0
                 tb[f't_mean_{quantum}'] = np.nan
                 tb[f't_first_{quantum}'] = np.nan

--- a/wfsim/core.py
+++ b/wfsim/core.py
@@ -5,13 +5,18 @@ import numpy as np
 from scipy.interpolate import interp1d
 from tqdm import tqdm
 
-from .load_resource import Resource
-from .utils import find_intervals_below_threshold, exporter
+from .load_resource import load_config
+from strax import exporter
 from . import units
+from .utils import find_intervals_below_threshold
 
 export, __all__ = exporter()
+__all__.append('PULSE_TYPE_NAMES')
 
 log = logging.getLogger('SimulationCore')
+
+PULSE_TYPE_NAMES = ('RESERVED', 's1', 's2', 'unknown', 'pi_el', 'pmt_ap')
+
 
 @export
 class Pulse(object):
@@ -20,7 +25,7 @@ class Pulse(object):
     def __init__(self, config):
         self.config = config
         self.config.update(getattr(self.config, self.__class__.__name__, {}))
-        self.resource = Resource(config)
+        self.resource = load_config(config)
 
         self.init_pmt_current_templates()
         self.init_spe_scaling_factor_distributions()
@@ -637,7 +642,7 @@ class RawData(object):
             pi_el=PhotoIonization_Electron(config),
             pmt_ap=PMT_Afterpulse(config),
         )
-        self.resource = Resource(self.config)
+        self.resource = load_config(self.config)
 
     def __call__(self, instructions, truth_buffer=[]):
 
@@ -728,28 +733,46 @@ class RawData(object):
 
     @staticmethod
     def symtype(ptype):
-        return ['s1', 's2', 'unknown', 'pi_el', 'pmt_ap'][ptype - 1]
+        return PULSE_TYPE_NAMES[ptype]
 
     def sim_data(self, instruction):
+        """Simulate a pulse according to instruction, and yield any additional instructions
+        for secondary electron afterpulses.
+        """
+        # Any additional fields in instruction correspond to temporary
+        # configuration overrides. No need to restore the old config:
+        # next instruction cannot but contain the same fields.
         if len(instruction) > 8:
             for par in instruction.dtype.names:
                 if par in self.config:
                     self.config[par] = instruction[par]
-        ptype = self.symtype(instruction['type'][0])
-        self.pulses[ptype](instruction)
-        self.pulses['pmt_ap'](self.pulses[ptype])
-        
-        for pt in [ptype, 'pmt_ap']:
+
+        # Simulate the primary pulse
+        primary_pulse = self.symtype(instruction['type'][0])
+        self.pulses[primary_pulse](instruction)
+
+        # Add PMT afterpulses, if requested
+        do_pmt_ap = self.config.get('enable_pmt_afterpulses', True)
+        if do_pmt_ap:
+            self.pulses['pmt_ap'](self.pulses[primary_pulse])
+
+        # Append pulses we just simulated to our cache
+        for pt in [primary_pulse, 'pmt_ap']:
+            if pt == 'pmt_ap' and not do_pmt_ap:
+                continue
+
             _pulses = getattr(self.pulses[pt], '_pulses')
             if len(_pulses) > 0:
                 self._pulses_cache += _pulses
-                self.last_pulse_end_time = max(self.last_pulse_end_time,
+                self.last_pulse_end_time = max(
+                    self.last_pulse_end_time,
                     np.max([p['right'] for p in _pulses]) * 10)
 
-        if ptype in ['s1', 's2']:
-            yield self.pulses['pi_el'].generate_instruction(
-                self.pulses[ptype], instruction)
-
+        # Make new instructions for electron afterpulses, if requested
+        if primary_pulse in ['s1', 's2']:
+            if self.config.get('enable_electron_afterpulses', True):
+                yield self.pulses['pi_el'].generate_instruction(
+                    self.pulses[primary_pulse], instruction)
             self.instruction_event_number = instruction['event_number'][0]
         
     def digitize_pulse_cache(self):

--- a/wfsim/core.py
+++ b/wfsim/core.py
@@ -644,7 +644,9 @@ class RawData(object):
         )
         self.resource = load_config(self.config)
 
-    def __call__(self, instructions, truth_buffer=[]):
+    def __call__(self, instructions, truth_buffer=None):
+        if truth_buffer is None:
+            truth_buffer = []
 
         # Pre-load some constents from config
         v = self.config['drift_velocity_liquid']
@@ -824,7 +826,7 @@ class RawData(object):
             # Operating directly on digitized downward waveform        
             if ix in self.config.get('special_thresholds', {}):
                 threshold = self.config['digitizer_reference_baseline'] \
-                    - self.config['special_thresholds'][str(pulse.channel)] - 1
+                    - self.config['special_thresholds'][str(ix)] - 1
             else:
                 threshold = self.config['digitizer_reference_baseline'] - self.config['zle_threshold'] - 1
 
@@ -846,41 +848,56 @@ class RawData(object):
                 yield ix, self.left + itv[0], self.left + itv[1], data[itv[0]:itv[1]+1]
 
     def get_truth(self, instruction, truth_buffer):
-        ix = np.argmin(truth_buffer['fill']) # Index of the first line not filled
-        pulse = self.pulses[self.symtype(instruction['type'][0])]
-        for name in 'photon', 'electron':
-            times = getattr(pulse, '_{name}_timings'.format(name=name), [])
-            if len(times) != 0:
-                truth_buffer[ix]['n_{name}'.format(name=name)] = len(times)
-                truth_buffer[ix]['t_mean_{name}'.format(name=name)] = np.mean(times)
-                truth_buffer[ix]['t_first_{name}'.format(name=name)] = np.min(times)
-                truth_buffer[ix]['t_last_{name}'.format(name=name)] = np.max(times)
-                truth_buffer[ix]['t_sigma_{name}'.format(name=name)] = np.std(times)
+        """Write truth in the first empty row of truth_buffer
+
+        :param instruction: Array of instructions that were simulated as a
+        single cluster, and should thus get one line in the truth info.
+        :param truth_buffer: Truth buffer to write in.
+        """
+        ix = np.argmin(truth_buffer['fill'])
+        tb = truth_buffer[ix]
+
+        peak_type = self.symtype(instruction['type'][0])
+        pulse = self.pulses[peak_type]
+
+        for quantum in 'photon', 'electron':
+            times = getattr(pulse, f'_{quantum}_timings', [])
+            if times:
+                tb[f'n_{quantum}'] = len(times)
+                tb[f't_mean_{quantum}'] = np.mean(times)
+                tb[f't_first_{quantum}'] = np.min(times)
+                tb[f't_last_{quantum}'] = np.max(times)
+                tb[f't_sigma_{quantum}'] = np.std(times)
             else:
-                if self.symtype(instruction['type'][0]) not in ['s1', 's2']: return
-                truth_buffer[ix]['n_{name}'.format(name=name)] = 0
-                truth_buffer[ix]['t_mean_{name}'.format(name=name)] = np.nan
-                truth_buffer[ix]['t_first_{name}'.format(name=name)] = np.nan
-                truth_buffer[ix]['t_last_{name}'.format(name=name)] = np.nan
-                truth_buffer[ix]['t_sigma_{name}'.format(name=name)] = np.nan
-            truth_buffer[ix]['endtime'] = truth_buffer[ix]['t_last_photon'].astype(np.int64)
-        # Area fraction top
-        channels = getattr(self.pulses[self.symtype(instruction['type'][0])], 
-            '_photon_channels', [])
+                # Peak does not have photons / electrons
+                tb[f'n_{quantum}'] = 0
+                tb[f't_mean_{quantum}'] = np.nan
+                tb[f't_first_{quantum}'] = np.nan
+                tb[f't_last_{quantum}'] = np.nan
+                tb[f't_sigma_{quantum}'] = np.nan
+            tb['endtime'] = tb['t_last_photon'].astype(np.int64)
+
+        channels = getattr(pulse, '_photon_channels', [])
         n_dpe = getattr(pulse, '_n_double_pe', 0)
         n_dpe_bot = getattr(pulse, '_n_double_pe_bot', 0)
-        truth_buffer[ix]['n_photon'] += n_dpe
-        truth_buffer[ix]['n_photon_bottom'] = np.sum(np.isin(channels, self.config['channels_bottom'])) \
-            + n_dpe_bot
-        # Copy-pasting instruction
-        for name in instruction.dtype.names:
-            if len(instruction) > 1 and name in 'txyz':
-                truth_buffer[ix][name] = np.average(instruction[name])
-            elif len(instruction) > 1 and name == 'amp':
-                truth_buffer[ix][name] = np.sum(instruction[name])
+        tb['n_photon'] += n_dpe
+        tb['n_photon_bottom'] = (
+            np.sum(np.isin(channels, self.config['channels_bottom']))
+            + n_dpe_bot)
+
+        # Summarize the instruction cluster in one row of the truth file
+        for field in instruction.dtype.names:
+            value = instruction[field]
+            if len(instruction) > 1 and field in 'txyz':
+                tb[field] = np.mean(value)
+            elif len(instruction) > 1 and field == 'amp':
+                tb[field] = np.sum(value)
             else:
-                truth_buffer[ix][name] = instruction[name][0]
-        truth_buffer[ix]['fill'] = True
+                # Cannot summarize intelligently: just take the first value
+                tb[field] = value[0]
+
+        # Signal this row is now filled, so it won't be overwritten
+        tb['fill'] = True
 
     def get_real_noise(self, length):
         """

--- a/wfsim/load_resource.py
+++ b/wfsim/load_resource.py
@@ -1,89 +1,95 @@
-import numpy as np
+from copy import deepcopy
 import os.path as osp
-from .utils import InterpolatingMap as itp_map
-from .utils import get_resource
 
-def get_resource_config(config):
-    if config['detector'] == 'XENON1T':
-        resource_config = {
-    'photon_area_distribution': 'XENON1T_spe_distributions.csv',
-    's1_light_yield_map':       'XENON1T_s1_xyz_ly_kr83m_SR1_pax-680_fdc-3d_v0.json',
-    's1_pattern_map':           'XENON1T_s1_xyz_patterns_interp_corrected_MCv2.1.0.json.gz',
-    's2_light_yield_map':       'XENON1T_s2_xy_ly_SR1_v2.2.json',
-    's2_pattern_map':           'XENON1T_s2_xy_patterns_top_corrected_MCv2.1.0.json.gz',
-    's2_per_pmt_params':        'Kr83m_Ddriven_per_pmt_params_dataframe.csv',
-    'ele_ap_cdfs':              'ele_after_pulse.npy',
-    'ele_ap_pdfs':              'x1t_se_afterpulse_delaytime.pkl.gz',
-    'photon_ap_cdfs':           'x1t_pmt_afterpulse_config.pkl.gz',
-    'noise_file':               'x1t_noise_170203_0850_00_small.npz',
-        }
-    if config['detector'] == 'XENONnT':
-        resource_config = {
-            'photon_area_distribution': 'XENONnT_spe_distributions.csv',
-            's1_pattern_map': 'XENONnT_s1_xyz_patterns_interp_corrected_MCv2.1.0.json.gz',
-            's2_pattern_map': 'XENONnT_s2_xy_patterns_topbottom_corrected_MCv3.0.0.json.gz',
+import numpy as np
+import strax
+import straxen
+
+
+_cached_configs = dict()
+
+
+def load_config(config):
+    """Create a Resource instance from the configuration
+
+    Uses a cache to avoid re-creating instances from the same config
+    """
+    h = strax.deterministic_hash(config)
+    if h in _cached_configs:
+        return _cached_configs[h]
+    result = Resource(config)
+    _cached_configs[h] = result
+    return result
+
+
+class Resource:
+    def __init__(self, config=None):
+        if config is None:
+            config = dict()
+        config = deepcopy(config)
+
+        files = {
             'ele_ap_pdfs': 'x1t_se_afterpulse_delaytime.pkl.gz',
-            'photon_ap_cdfs': 'xnt_pmt_afterpulse_config.pkl.gz',
+            'ele_ap_cdfs': 'ele_after_pulse.npy',
             'noise_file': 'x1t_noise_170203_0850_00_small.npz',
         }
+        if config['detector'] == 'XENON1T':
+            files.update({
+                'photon_area_distribution': 'XENON1T_spe_distributions.csv',
+                's1_light_yield_map': 'XENON1T_s1_xyz_ly_kr83m_SR1_pax-680_fdc-3d_v0.json',
+                's1_pattern_map': 'XENON1T_s1_xyz_patterns_interp_corrected_MCv2.1.0.json.gz',
+                's2_light_yield_map': 'XENON1T_s2_xy_ly_SR1_v2.2.json',
+                's2_pattern_map': 'XENON1T_s2_xy_patterns_top_corrected_MCv2.1.0.json.gz',
+                's2_per_pmt_params': 'Kr83m_Ddriven_per_pmt_params_dataframe.csv',
+                'photon_ap_cdfs': 'x1t_pmt_afterpulse_config.pkl.gz',
+            })
+        elif config['detector'] == 'XENONnT':
+            files.update({
+                'photon_area_distribution': 'XENONnT_spe_distributions.csv',
+                's1_pattern_map': 'XENONnT_s1_xyz_patterns_corrected_MCv3.0.0.pkl',
+                's2_pattern_map': 'XENONnT_s2_xy_patterns_topbottom_corrected_MCv3.0.0.pkl',
+                'photon_ap_cdfs': 'xnt_pmt_afterpulse_config.pkl.gz',
+            })
+        else:
+            raise ValueError(f"Unsupported detector {config['detector']}")
 
-    for k in resource_config:
-        resource_config[k] = osp.join('https://raw.githubusercontent.com/XENONnT/strax_auxiliary_files/'
-                         'master/fax_files', resource_config[k])
-    return resource_config
+        commit = 'master'   # Replace this by a commit hash if you feel solid and responsible
+        url_base = f'https://raw.githubusercontent.com/XENONnT/strax_auxiliary_files/{commit}/fax_files'
+        for k, v in files.items():
+            if v.startswith('/'):
+                print(f"WARNING: Using local file {v} for a resource. "
+                      f"Do not set this as a default or TravisCI tests will break")
+            files[k] = osp.join(url_base, v)
 
-class Resource(object):
-    # The private nested inner class __Resource would only be instantiate once 
+        self.photon_area_distribution = straxen.get_resource(files['photon_area_distribution'], fmt='csv')
 
-    class __Resource(object):
+        if config['detector']== 'XENON1T':
+            self.s1_pattern_map = make_map(files['s1_pattern_map'], fmt='json.gz')
+            self.s1_light_yield_map = make_map(files['s1_light_yield_map'], fmt='json')
+            self.s2_light_yield_map = make_map(files['s2_light_yield_map'], fmt='json')
+            self.s2_per_pmt_params = straxen.get_resource(files['s2_per_pmt_params'], fmt='csv')
 
-        def __init__(self, config={}):
-            self.config = get_resource_config(config)
+        if config['detector'] == 'XENONnT':
+            self.s1_pattern_map = make_map(files['s1_pattern_map'], fmt='pkl')
+            lymap = deepcopy(self.s1_pattern_map)
+            lymap.data['map'] = np.sum(lymap.data['map'][:][:][:], axis=3)
+            self.s1_light_yield_map = lymap
 
-            # Pulse
-            self.photon_area_distribution = get_resource(self.config['photon_area_distribution'], fmt='csv')
+            self.s2_pattern_map = make_map(files['s2_pattern_map'], fmt='pkl')
+            lymap = deepcopy(self.s2_pattern_map)
+            lymap.data['map'] = np.sum(lymap.data['map'][:][:], axis=2)
+            self.s2_light_yield_map = lymap
 
-            if config['detector']== 'XENON1T':
-                # S1
-                self.s1_light_yield_map = itp_map(self.config['s1_light_yield_map'], fmt='json')
-                self.s1_pattern_map = itp_map(self.config['s1_pattern_map'], fmt='json.gz')
-                # S2
-                self.s2_light_yield_map = itp_map(self.config['s2_light_yield_map'], fmt='json')
-                self.s2_per_pmt_params = get_resource(self.config['s2_per_pmt_params'], fmt='csv')
+        # Electron After Pulses compressed, haven't figure out how pkl.gz works
+        self.uniform_to_ele_ap = straxen.get_resource(files['ele_ap_pdfs'], fmt='pkl.gz')
 
-            if config['detector'] == 'XENONnT':
-                self.s1_light_yield =  get_resource('/dali/lgrandi/pgaemers/fax_files/XENONnT_s1_xyz_patterns_corrected_MCv3.0.0.json.gz',fmt = 'json.gz')
-                self.s1_light_yield['map'] = np.sum(self.s1_light_yield['map'][:][:][:],axis=3)
-                self.s1_light_yield_map = itp_map(self.s1_light_yield)
-                self.s1_pattern_map = itp_map(
-                '/dali/lgrandi/pgaemers/fax_files/XENONnT_s1_xyz_patterns_corrected_MCv3.0.0.json.gz', fmt='json.gz')
+        # Photon After Pulses
+        self.uniform_to_pmt_ap = straxen.get_resource(files['photon_ap_cdfs'], fmt='pkl.gz')
 
-                self.s2_light_yield = get_resource(
-                    '/dali/lgrandi/pgaemers/fax_files/XENONnT_s2_xy_patterns_topbottom_corrected_MCv3.0.0.json.gz',
-                    fmt='json.gz')
-                self.s2_light_yield['map'] = np.sum(self.s2_light_yield['map'][:][:], axis=2)
-                self.s2_light_yield_map = itp_map(self.s2_light_yield)
-                self.s2_pattern_map = itp_map(
-                        '/dali/lgrandi/pgaemers/fax_files/XENONnT_s2_xy_patterns_topbottom_corrected_MCv3.0.0.json.gz',
-                        fmt='json.gz')
+        # Noise sample
+        self.noise_data = straxen.get_resource(files['noise_file'], fmt='npy')['arr_0'].flatten()
 
-            # Electron After Pulses compressed, haven't figure out how pkl.gz works
-            self.uniform_to_ele_ap = get_resource(self.config['ele_ap_pdfs'], fmt='pkl.gz')
 
-            # Photon After Pulses
-            self.uniform_to_pmt_ap = get_resource('/dali/lgrandi/pgaemers/fax_files/xnt_pmt_afterpulse_config.pkl.gz', fmt='pkl.gz')
-                # get_resource(self.config['photon_ap_cdfs'], fmt='pkl.gz')
-
-            # Noise sample
-            self.noise_data = get_resource(self.config['noise_file'], fmt='npy')['arr_0'].flatten()
-
-            self.config.update(config)
-    instance = None
-    
-    def __init__(self, config={}):
-        self.config = config
-        if not Resource.instance:
-            Resource.instance = Resource.__Resource(config)
-    
-    def __getattr__(self, name):
-        return getattr(self.instance, name)
+def make_map(map_file: str, fmt='text'):
+    map_data = straxen.get_resource(map_file, fmt)
+    return straxen.InterpolatingMap(map_data)

--- a/wfsim/pax_interface.py
+++ b/wfsim/pax_interface.py
@@ -12,7 +12,7 @@ import pandas as pd
 from .core import RawData
 from .pax_datastructure import datastructure
 from .strax_interface import *
-from .utils import exporter
+from strax import exporter
 from straxen.common import get_resource
 
 export, __all__ = exporter()

--- a/wfsim/utils.py
+++ b/wfsim/utils.py
@@ -1,121 +1,11 @@
-import io
-import socket
-import sys
-import tarfile
-import os.path as osp
-import os
-import inspect
-import urllib.request
-
-import logging
-import re
-
-def exporter(export_self=False):
-    """Export utility modified from https://stackoverflow.com/a/41895194
-    Returns export decorator, __all__ list
-    """
-    all_ = []
-    if export_self:
-        all_.append('exporter')
-
-    def decorator(obj):
-        all_.append(obj.__name__)
-        return obj
-
-    return decorator, all_
-
-export, __all__ = exporter(export_self=True)
-
+import numba
 import numpy as np
-import json, gzip
-import pickle
-
-cache_dict = dict()
-
-@export
-def get_resource(x, fmt='text'):
-    """Return contents of file or URL x
-    :param binary: Resource is binary. Return bytes instead of a string.
-    """
-    is_binary = fmt != 'text'
-
-    # Try to retrieve from in-memory cache
-    if x in cache_dict:
-        return cache_dict[x]
-
-    if '://' in x:
-        # Web resource; look first in on-disk cache
-        # to prevent repeated downloads.
-        #cache_fn = strax.utils.deterministic_hash(x)
-        cache_fn = x.split('/')[-1]
-        cache_folders = ['./resource_cache',
-                         '/tmp/straxen_resource_cache',
-                         '/dali/lgrandi/strax/resource_cache']
-        for cache_folder in cache_folders:
-            try:
-                os.makedirs(cache_folder, exist_ok=True)
-            except (PermissionError, OSError):
-                continue
-            cf = osp.join(cache_folder, cache_fn)
-            if osp.exists(cf):
-                return get_resource(cf, fmt=fmt)
-
-        # Not found in any cache; download
-        result = urllib.request.urlopen(x).read()
-        if not is_binary:
-            result = result.decode()
-
-        # Store in as many caches as possible
-        m = 'wb' if is_binary else 'w'
-        available_cf = None
-        for cache_folder in cache_folders:
-            if not osp.exists(cache_folder):
-                continue
-            cf = osp.join(cache_folder, cache_fn)
-            try:
-                with open(cf, mode=m) as f:
-                    f.write(result)
-            except Exception:
-                pass
-            else:
-                available_cf = cf
-        if available_cf is None:
-            raise RuntimeError(
-                "Could not load {x},"
-                "none of the on-disk caches are writeable??")
-
-        # Retrieve result from file-cache
-        # (so we only need one format-parsing logic)
-        return get_resource(available_cf, fmt=fmt)
-
-    # File resource
-    if fmt == 'npy':
-        result = np.load(x)
-    if fmt == 'npy_pickle':
-        result = np.load(x, allow_pickle=True)
-    elif fmt == 'binary':
-        with open(x, mode='rb') as f:
-            result = f.read()
-    elif fmt == 'text':
-        with open(x, mode='r') as f:
-            result = f.read()
-    elif fmt == 'json':
-        with open(x, mode='r') as f:
-            result = json.load(f)
-    elif fmt == 'json.gz':
-        with gzip.open(x, 'rb') as f:
-            result = json.load(f)
-    elif fmt == 'pkl.gz':
-        with gzip.open(x, 'rb') as f:
-            result = pickle.load(f)
-    elif fmt == 'csv':
-        result = pd.read_csv(x)
-    elif fmt == 'hdf':
-        result = pd.read_hdf(x)
-    return result
-
 import pandas as pd
 from scipy.interpolate import interp1d
+
+import strax
+export, __all__ = strax.exporter(export_self=True)
+
 
 def init_spe_scaling_factor_distributions(file):
     # Extract the spe pdf from a csv file into a pandas dataframe
@@ -135,146 +25,22 @@ def init_spe_scaling_factor_distributions(file):
             scaled_bins = np.zeros_like(cdf)
 
         uniform_to_pe_arr.append(interp1d(cdf, scaled_bins))
+
     if uniform_to_pe_arr != []:
         return uniform_to_pe_arr
-    
-from scipy.spatial import cKDTree
-
-class InterpolateAndExtrapolate(object):
-    """Linearly interpolate- and extrapolate using inverse-distance
-    weighted averaging between nearby points.
-    """
-
-    def __init__(self, points, values, neighbours_to_use=None):
-        """
-        :param points: array (n_points, n_dims) of coordinates
-        :param values: array (n_points) of values
-        :param neighbours_to_use: Number of neighbouring points to use for
-        averaging. Default is 2 * dimensions of points.
-        """
-        self.kdtree = cKDTree(points)
-        self.values = values
-        if neighbours_to_use is None:
-            neighbours_to_use = points.shape[1] * 2
-        self.neighbours_to_use = neighbours_to_use
-
-    def __call__(self, points):
-        distances, indices = self.kdtree.query(points, self.neighbours_to_use)
-        # If one of the coordinates is NaN, the neighbour-query fails.
-        # If we don't filter these out, it would result in an IndexError
-        # as the kdtree returns an invalid index if it can't find neighbours.
-        result = np.ones(len(points)) * float('nan')
-        valid = (distances < float('inf')).max(axis=-1)
-        result[valid] = np.average(
-            self.values[indices[valid]],
-            weights=1/np.clip(distances[valid], 1e-6, float('inf')),
-            axis=-1)
-        return result
-
-class InterpolateAndExtrapolateArray(InterpolateAndExtrapolate):
-
-    def __call__(self, points):
-        distances, indices = self.kdtree.query(points, self.neighbours_to_use)
-        result = np.ones((len(points), self.values.shape[-1])) * float('nan')
-        valid = (distances < float('inf')).max(axis=-1)
-
-        values = self.values[indices[valid]]
-        weights = np.repeat(1/np.clip(distances[valid], 1e-6, float('inf')), values.shape[-1]).reshape(values.shape)
-
-        result[valid] = np.average(values, weights=weights, axis=-2)
-        return result
 
 
-class InterpolatingMap(object):
-    """Correction map that computes values using inverse-weighted distance
-    interpolation.
-
-    The map must be specified as a json translating to a dictionary like this:
-        'coordinate_system' :   [[x1, y1], [x2, y2], [x3, y3], [x4, y4], ...],
-        'map' :                 [value1, value2, value3, value4, ...]
-        'another_map' :         idem
-        'name':                 'Nice file with maps',
-        'description':          'Say what the maps are, who you are, etc',
-        'timestamp':            unix epoch seconds timestamp
-
-    with the straightforward generalization to 1d and 3d.
-
-    The default map name is 'map', I'd recommend you use that.
-
-    For a 0d placeholder map, use
-        'points': [],
-        'map': 42,
-        etc
-
-    """
-    data_field_names = ['timestamp', 'description', 'coordinate_system',
-                    'name', 'irregular']
-    def __init__(self, data, fmt = None):
-        self.log = logging.getLogger('InterpolatingMap')
-        if fmt is not None:
-            self.data = get_resource(data, fmt)
-        else:
-            self.data = data
-
-        self.coordinate_system = cs = self.data['coordinate_system']
-        if not len(cs):
-            self.dimensions = 0
-        elif isinstance(cs[0], list):
-            if isinstance(cs[0][0], str):
-                grid = [np.linspace(left, right, points) for axis, (left, right, points) in cs]
-                cs = np.array(np.meshgrid(*grid))
-                cs = np.transpose(cs, np.roll(np.arange(len(grid)+1), -1))
-                cs = np.array(cs).reshape((-1, len(grid)))
-                self.dimensions =len(grid)
-            else:
-                self.dimensions = len(cs[0])
-        else:
-            self.dimensions = 1
-
-        self.interpolators = {}
-        self.map_names = sorted([k for k in self.data.keys()
-                                 if k not in self.data_field_names])
-        self.log.debug('Map name: %s' % self.data['name'])
-        self.log.debug('Map description:\n    ' +
-                       re.sub(r'\n', r'\n    ', self.data['description']))
-        self.log.debug("Map names found: %s" % self.map_names)
-
-        for map_name in self.map_names:
-            map_data = np.array(self.data[map_name])
-            if self.dimensions == 0:
-                # 0 D -- placeholder maps which take no arguments
-                # and always return a single value
-                def itp_fun(positions):
-                    return map_data * np.ones_like(positions)
-            elif len(map_data.shape) == self.dimensions + 1:
-                map_data = map_data.reshape((-1, map_data.shape[-1]))
-                itp_fun = InterpolateAndExtrapolateArray(points=np.array(cs),
-                                                    values=np.array(map_data))
-            else:
-                itp_fun = InterpolateAndExtrapolate(points=np.array(cs),
-                                                    values=np.array(map_data))
-
-            self.interpolators[map_name] = itp_fun
-
-    def __call__(self, positions, map_name='map'):
-        """Returns the value of the map at the position given by coordinates
-        :param positions: array (n_dim) or (n_points, n_dim) of positions
-        :param map_name: Name of the map to use. Default is 'map'.
-        """
-        return self.interpolators[map_name](positions)
-
-import numba
 @export
 @numba.jit(numba.int32(numba.int64[:], numba.int64, numba.int64, numba.int64[:, :]),
            nopython=True)
 def find_intervals_below_threshold(w, threshold, holdoff, result_buffer):
-    """Fills result_buffer with l, r bounds of intervals in w > threshold.
+    """Fills result_buffer with l, r bounds of intervals in w < threshold.
     :param w: Waveform to do hitfinding in
     :param threshold: Threshold for including an interval
     :param result_buffer: numpy N*2 array of ints, will be filled by function.
                           if more than N intervals are found, none past the first N will be processed.
     :returns : number of intervals processed
-    Boundary indices are inclusive, i.e. the right boundary is the last index which was > threshold
+    Boundary indices are inclusive, i.e. the right boundary is the last index which was < threshold
     """
     result_buffer_size = len(result_buffer)
     last_index_in_w = len(w) - 1
@@ -294,8 +60,8 @@ def find_intervals_below_threshold(w, threshold, holdoff, result_buffer):
 
             current_interval_end = i
 
-        if ((i == last_index_in_w and in_interval) or 
-            (x >= threshold and i >= current_interval_end + holdoff and in_interval)):
+        if ((i == last_index_in_w and in_interval) or
+                (x >= threshold and i >= current_interval_end + holdoff and in_interval)):
             # End of the current interval
             in_interval = False
 
@@ -307,5 +73,5 @@ def find_intervals_below_threshold(w, threshold, holdoff, result_buffer):
             if current_interval == result_buffer_size:
                 result_buffer[current_interval, 1] = len(w) - 1
 
-    n_intervals = current_interval      # No +1, as current_interval was incremented also when the last interval closed
+    n_intervals = current_interval  # No +1, as current_interval was incremented also when the last interval closed
     return n_intervals


### PR DESCRIPTION
This fixes a few things in the truth info writing.
  * Due to an indexing quirk, the truth buffer was never actually marked as cleared in `final_results` of `ChunkRawRecords`. As a result, there were many duplicate entries in the truth output for long datasets.
  * There was a [mutable default](https://docs.python-guide.org/writing/gotchas/) for `truth_info` in RawData. I don't think this is actually used, so perhaps we can just remove it instead of using the None-default trick?
  * Maybe this was a feature, not a bug, but for afterpulse-like peak the t_first_electron etc. fields were not set to NaN when there are no electrons. Since the truth buffer gets reused without being cleared, I think this would lead to values from old peaks showing up in the truth for new peaks. Just let me know if I misunderstood.
  * There was an undefined variable 'pulse' in the handling of channel-specific self-trigger / ZLE thresholds. This isn't related to truth file writing; I just saw it accidentally because it's right next to it. I hope I put the right variable in now, but I don't know -- the test apparently don't hit this code.

(I could also not resist a slight cleanup / annotation of the truth writing code while trying to understand it).

(The Travis build will fail until we apply the fix in #36)