### PR TITLE
edit truth handing for non-detected signals

### DIFF
--- a/wfsim/core.py
+++ b/wfsim/core.py
@@ -856,18 +856,20 @@ class RawData(object):
         """
         ix = np.argmin(truth_buffer['fill'])
         tb = truth_buffer[ix]
-
         peak_type = self.symtype(instruction['type'][0])
         pulse = self.pulses[peak_type]
 
         for quantum in 'photon', 'electron':
             times = getattr(pulse, f'_{quantum}_timings', [])
+            # Set an endtime (if times has no length)
+            tb['endtime'] = np.mean(instruction['time'])
             if len(times):
                 tb[f'n_{quantum}'] = len(times)
                 tb[f't_mean_{quantum}'] = np.mean(times)
                 tb[f't_first_{quantum}'] = np.min(times)
                 tb[f't_last_{quantum}'] = np.max(times)
                 tb[f't_sigma_{quantum}'] = np.std(times)
+                tb['endtime'] = tb['t_last_photon']
             else:
                 # Peak does not have photons / electrons
                 # zero-photon afterpulses can be removed from truth info
@@ -878,7 +880,6 @@ class RawData(object):
                 tb[f't_first_{quantum}'] = np.nan
                 tb[f't_last_{quantum}'] = np.nan
                 tb[f't_sigma_{quantum}'] = np.nan
-            tb['endtime'] = tb['t_last_photon'].astype(np.int64)
 
         channels = getattr(pulse, '_photon_channels', [])
         n_dpe = getattr(pulse, '_n_double_pe', 0)


### PR DESCRIPTION
This fix is implemented by @petergaemers.

For signals that were not detected, no truth info was written as the condition on line https://github.com/XENONnT/WFSim/blob/02bcef02c83b42af5daae1df969913078dbba9a2/wfsim/strax_interface.py#L226 was never satisfied for np.nans.

This resulted in fewer S1's in the truth than we requested in the instructions.