### PR TITLE
Allow config override of files

### DIFF
--- a/wfsim/load_resource.py
+++ b/wfsim/load_resource.py
@@ -33,7 +33,8 @@ class Resource:
             'ele_ap_cdfs': 'ele_after_pulse.npy',
             'noise_file': 'x1t_noise_170203_0850_00_small.npz',
         }
-        XENON1T_default_files = {
+        if config['detector'] == 'XENON1T':
+            files.update({
                 'photon_area_distribution': 'XENON1T_spe_distributions.csv',
                 's1_light_yield_map': 'XENON1T_s1_xyz_ly_kr83m_SR1_pax-680_fdc-3d_v0.json',
                 's1_pattern_map': 'XENON1T_s1_xyz_patterns_interp_corrected_MCv2.1.0.json.gz',
@@ -41,24 +42,18 @@ class Resource:
                 's2_pattern_map': 'XENON1T_s2_xy_patterns_top_corrected_MCv2.1.0.json.gz',
                 's2_per_pmt_params': 'Kr83m_Ddriven_per_pmt_params_dataframe.csv',
                 'photon_ap_cdfs': 'x1t_pmt_afterpulse_config.pkl.gz',
-        }
-        XENONnT_default_files = {
+            })
+        elif config['detector'] == 'XENONnT':
+            files.update({
                 'photon_area_distribution': 'XENONnT_spe_distributions.csv',
                 's1_pattern_map': 'XENONnT_s1_xyz_patterns_corrected_MCv3.0.0.pkl',
                 's2_pattern_map': 'XENONnT_s2_xy_patterns_topbottom_corrected_MCv3.0.0.pkl',
                 'photon_ap_cdfs': 'xnt_pmt_afterpulse_config.pkl.gz',
-        }
-        if config['detector'] == 'XENON1T':
-            files.update(
-                {key: config.get(key, val) for (key, val) in XENON1T_default_files.items()}
-            )
-        elif config['detector'] == 'XENONnT':
-            files.update(
-                {key: config.get(key, val) for (key, val) in XENONnT_default_files.items()}
-            )
+            })
         else:
             raise ValueError(f"Unsupported detector {config['detector']}")
 
+        files.update(config)    # Allowing user to replace default with specified files
         commit = 'master'   # Replace this by a commit hash if you feel solid and responsible
         url_base = f'https://raw.githubusercontent.com/XENONnT/strax_auxiliary_files/{commit}/fax_files'
         for k, v in files.items():

--- a/wfsim/load_resource.py
+++ b/wfsim/load_resource.py
@@ -33,8 +33,7 @@ class Resource:
             'ele_ap_cdfs': 'ele_after_pulse.npy',
             'noise_file': 'x1t_noise_170203_0850_00_small.npz',
         }
-        if config['detector'] == 'XENON1T':
-            files.update({
+        XENON1T_default_files = {
                 'photon_area_distribution': 'XENON1T_spe_distributions.csv',
                 's1_light_yield_map': 'XENON1T_s1_xyz_ly_kr83m_SR1_pax-680_fdc-3d_v0.json',
                 's1_pattern_map': 'XENON1T_s1_xyz_patterns_interp_corrected_MCv2.1.0.json.gz',
@@ -42,14 +41,21 @@ class Resource:
                 's2_pattern_map': 'XENON1T_s2_xy_patterns_top_corrected_MCv2.1.0.json.gz',
                 's2_per_pmt_params': 'Kr83m_Ddriven_per_pmt_params_dataframe.csv',
                 'photon_ap_cdfs': 'x1t_pmt_afterpulse_config.pkl.gz',
-            })
-        elif config['detector'] == 'XENONnT':
-            files.update({
+        }
+        XENONnT_default_files = {
                 'photon_area_distribution': 'XENONnT_spe_distributions.csv',
                 's1_pattern_map': 'XENONnT_s1_xyz_patterns_corrected_MCv3.0.0.pkl',
                 's2_pattern_map': 'XENONnT_s2_xy_patterns_topbottom_corrected_MCv3.0.0.pkl',
                 'photon_ap_cdfs': 'xnt_pmt_afterpulse_config.pkl.gz',
-            })
+        }
+        if config['detector'] == 'XENON1T':
+            files.update(
+                {key: config.get(key, val) for (key, val) in XENON1T_default_files.items()}
+            )
+        elif config['detector'] == 'XENONnT':
+            files.update(
+                {key: config.get(key, val) for (key, val) in XENONnT_default_files.items()}
+            )
         else:
             raise ValueError(f"Unsupported detector {config['detector']}")
 


### PR DESCRIPTION
Amends load_resource.py to allow different filenames for light yield maps, etc to be passed via the config. Default hard-coded files are preserved. Unity light yields are helpful for understanding reconstruction efficiencies.

Note: I also added "placeholder_map.json" to strax_auxilliary_files. I think you could try this as the default for nT instead of doing [this](https://github.com/XENONnT/WFSim/blob/cce8748785cf1a208c44be6df84655b77ad60f80/wfsim/core.py#L247) but I didn't want to mess with it.