### PR TITLE
Catch up strax

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open('HISTORY.md') as file:
 
 setuptools.setup(
     name='wfsim',
-    version='0.0.3',
+    version='0.0.4',
     description='XENONnT Waveform simulator',
     author='Wfsim contributors, the XENON collaboration',
     url='https://github.com/XENONnT/wfsim',

--- a/tests/test_wfsim.py
+++ b/tests/test_wfsim.py
@@ -18,7 +18,7 @@ def test_sim_nt():
             config=dict(nchunk=1, event_rate=1, chunk_size=10,
                         detector='XENONnT',
                         to_pe_file= 'https://raw.githubusercontent.com/XENONnT/'
-                                       'strax_auxiliary_files/master/to_pe_nt.npy',
+                                       'strax_auxiliary_files/master/fax_files/to_pe_nt.npy',
                         fax_config='https://raw.githubusercontent.com/XENONnT/'
                                    'strax_auxiliary_files/master/fax_files/fax_config_nt.json',
                         **straxen.contexts.xnt_common_config),

--- a/tests/test_wfsim.py
+++ b/tests/test_wfsim.py
@@ -17,7 +17,7 @@ def test_sim_nt():
             register=wfsim.RawRecordsFromFax,
             config=dict(nchunk=1, event_rate=1, chunk_size=10,
                         detector='XENONnT',
-                        to_pe_file'= 'https://raw.githubusercontent.com/XENONnT/'
+                        to_pe_file= 'https://raw.githubusercontent.com/XENONnT/'
                                        'strax_auxiliary_files/master/to_pe_nt.npy'),
                         fax_config='https://raw.githubusercontent.com/XENONnT/'
                                    'strax_auxiliary_files/master/fax_files/fax_config_nt.json',

--- a/tests/test_wfsim.py
+++ b/tests/test_wfsim.py
@@ -17,11 +17,8 @@ def test_sim_nt():
             register=wfsim.RawRecordsFromFax,
             config=dict(nchunk=1, event_rate=1, chunk_size=10,
                         detector='XENONnT',
-                        n_tpc_pmts=494,
                         fax_config='https://raw.githubusercontent.com/XENONnT/'
-                           'strax_auxiliary_files/master/fax_files/fax_config_nt.json',
-                        to_pe_file='https://raw.githubusercontent.com/XENONnT/'
-                           'strax_auxiliary_files/master/fax_files/to_pe_nt.npy',
+                                   'strax_auxiliary_files/master/fax_files/fax_config_nt.json',
                         **straxen.contexts.xnt_common_config),
             **straxen.contexts.common_opts)
 
@@ -37,7 +34,7 @@ def test_sim():
             register=wfsim.RawRecordsFromFax,
             config=dict(nchunk=1, event_rate=1, chunk_size=10,
                         detector='XENON1T',
-                        **straxen.context.x1t_common_config),
+                        **straxen.contexts.x1t_common_config),
             **straxen.contexts.common_opts)
 
         rr = st.get_array(run_id, 'raw_records')

--- a/tests/test_wfsim.py
+++ b/tests/test_wfsim.py
@@ -17,6 +17,8 @@ def test_sim_nt():
             register=wfsim.RawRecordsFromFax,
             config=dict(nchunk=1, event_rate=1, chunk_size=10,
                         detector='XENONnT',
+                        to_pe_file'= 'https://raw.githubusercontent.com/XENONnT/'
+                                       'strax_auxiliary_files/master/to_pe_nt.npy'),
                         fax_config='https://raw.githubusercontent.com/XENONnT/'
                                    'strax_auxiliary_files/master/fax_files/fax_config_nt.json',
                         **straxen.contexts.xnt_common_config),

--- a/tests/test_wfsim.py
+++ b/tests/test_wfsim.py
@@ -17,8 +17,14 @@ def test_sim_nt():
             register=wfsim.RawRecordsFromFax,
             config=dict(nchunk=1, event_rate=1, chunk_size=10,
                         detector='XENONnT',
-                        fax_config='https://raw.githubusercontent.com/XENONnT/'
-                                   'strax_auxiliary_files/master/fax_files/fax_config_nt.json'),
+                        n_tpc_pmts=494,
+                fax_config='https://raw.githubusercontent.com/XENONnT/'
+                           'strax_auxiliary_files/master/fax_files/fax_config_nt.json',
+                to_pe_file='https://raw.githubusercontent.com/XENONnT/'
+                           'strax_auxiliary_files/master/fax_files/to_pe_nt.npy',
+                gain_model=('to_pe_per_run',
+                            'https://raw.githubusercontent.com/XENONnT/'
+                            'strax_auxiliary_files/master/fax_files/to_pe_nt.npy'),),
             **straxen.contexts.common_opts)
 
         rr = st.get_array(run_id, 'raw_records')

--- a/wfsim/__init__.py
+++ b/wfsim/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.0.3'
+__version__ = '0.0.4'
 
 from .core import *
 from .strax_interface import *

--- a/wfsim/load_resource.py
+++ b/wfsim/load_resource.py
@@ -46,8 +46,8 @@ class Resource:
         elif config['detector'] == 'XENONnT':
             files.update({
                 'photon_area_distribution': 'XENONnT_spe_distributions.csv',
-                's1_pattern_map': 'XENONnT_s1_xyz_patterns_corrected_MCv3.0.0.pkl',
-                's2_pattern_map': 'XENONnT_s2_xy_patterns_topbottom_corrected_MCv3.0.0.pkl',
+                's1_pattern_map': 'XENONnT_s1_xyz_patterns_corrected_MCv3.1.0.pkl',
+                's2_pattern_map': 'XENONnT_s2_xy_patterns_topbottom_corrected_MCv3.1.0.pkl',
                 'photon_ap_cdfs': 'xnt_pmt_afterpulse_config.pkl.gz',
             })
         else:

--- a/wfsim/load_resource.py
+++ b/wfsim/load_resource.py
@@ -46,8 +46,8 @@ class Resource:
         elif config['detector'] == 'XENONnT':
             files.update({
                 'photon_area_distribution': 'XENONnT_spe_distributions.csv',
-                's1_pattern_map': 'XENONnT_s1_xyz_patterns_corrected_MCv3.1.0.pkl',
-                's2_pattern_map': 'XENONnT_s2_xy_patterns_topbottom_corrected_MCv3.1.0.pkl',
+                's1_pattern_map': 'XENONnT_s1_xyz_patterns_corrected_MCv3.1.0_disks.pkl',
+                's2_pattern_map': 'XENONnT_s2_xy_patterns_topbottom_corrected_MCv3.1.0_disks.pkl',
                 'photon_ap_cdfs': 'xnt_pmt_afterpulse_config.pkl.gz',
             })
         else:

--- a/wfsim/pax_interface.py
+++ b/wfsim/pax_interface.py
@@ -61,7 +61,7 @@ EventProxy = namedtuple('EventProxy', ['data', 'event_number', 'block_id'])
 
 default_config = {
     'fax_file':None,
-    'experiment':'XENON1T',
+    'detector':'XENON1T',
     'event_rate':1, # Must set to one so chunk can be interpret as an event
     'chunk_size':1, # Must set to one so chunk can be interpret as an event
     'nchunk':200, # Number of events
@@ -69,7 +69,7 @@ default_config = {
         'strax_auxiliary_files/master/fax_files/fax_config.json'),
     'samples_to_store_before':2,
     'samples_to_store_after':20,
-    'right_raw_extension':10000,
+    'right_raw_extension':50000,
     'trigger_window':50,
     'zle_threshold':0,
     'run_number':10000, # Change run_number to prevent overwritting
@@ -136,7 +136,7 @@ class PaxEventSimulator(object):
             self.last_event_written = None
             
             self.output_dir = os.path.join(self.config['output_name'], 
-                '%s_MC_%d' % (self.config['experiment'], self.config['run_number']))
+                '%s_MC_%d' % (self.config['detector'], self.config['run_number']))
             os.makedirs(self.output_dir, exist_ok=True)
             
             # Start the temporary file. Events will first be written here, until events_per_file is reached
@@ -172,7 +172,7 @@ class PaxEventSimulator(object):
             # Rename the temporary file to reflect the events we've written to it
             os.rename(self.tempfile,
                       os.path.join(self.output_dir,
-                            '%s-%d-%09d-%09d-%09d.%s' % (self.config['experiment'],
+                            '%s-%d-%09d-%09d-%09d.%s' % (self.config['detector'],
                                                          self.config['run_number'],
                                                          self.first_event_in_current_file,
                                                          self.last_event_written,
@@ -187,7 +187,7 @@ class PaxEventSimulator(object):
 
         # Save truth file as well
         truth_file_path = os.path.join(self.output_plugin.output_dir,
-                '%s-%d-truth.csv' % (self.config['experiment'], self.config['run_number']))
+                '%s-%d-truth.csv' % (self.config['detector'], self.config['run_number']))
         truth = pd.DataFrame(self.pax_event.truth_buffer[self.pax_event.truth_buffer['fill']])
         truth.drop(columns='fill', inplace=True)
         truth.to_csv(truth_file_path, index=False)

--- a/wfsim/strax_interface.py
+++ b/wfsim/strax_interface.py
@@ -307,7 +307,8 @@ class FaxSimulatorPlugin(strax.Plugin):
         c = self.config
         c.update(get_resource(c['fax_config'], fmt='json'))
         # Update gains to the nT defaults
-        self.to_pe = get_to_pe(self.run_id, self.config['to_pe_file'])
+        self.to_pe = get_to_pe(self.run_id, self.config['to_pe_file'],
+                              len(config['channels_in_detector']['tpc']))
         c['gains'] = 1 / self.to_pe * (1e-8 * 2.25 / 2**14) / (1.6e-19 * 10 * 50)
         c['gains'][self.to_pe==0] = 0
 

--- a/wfsim/strax_interface.py
+++ b/wfsim/strax_interface.py
@@ -307,7 +307,7 @@ class FaxSimulatorPlugin(strax.Plugin):
         c = self.config
         c.update(get_resource(c['fax_config'], fmt='json'))
         # Update gains to the nT defaults
-        self.to_pe = get_to_pe(self.run_id, self.config['to_pe_file'],
+        self.to_pe = get_to_pe(self.run_id, ('to_pe_per_run',self.config['to_pe_file']),
                               len(c['channels_in_detector']['tpc']))
         c['gains'] = 1 / self.to_pe * (1e-8 * 2.25 / 2**14) / (1.6e-19 * 10 * 50)
         c['gains'][self.to_pe==0] = 0

--- a/wfsim/strax_interface.py
+++ b/wfsim/strax_interface.py
@@ -308,7 +308,7 @@ class FaxSimulatorPlugin(strax.Plugin):
         c.update(get_resource(c['fax_config'], fmt='json'))
         # Update gains to the nT defaults
         self.to_pe = get_to_pe(self.run_id, self.config['to_pe_file'],
-                              len(config['channels_in_detector']['tpc']))
+                              len(c['channels_in_detector']['tpc']))
         c['gains'] = 1 / self.to_pe * (1e-8 * 2.25 / 2**14) / (1.6e-19 * 10 * 50)
         c['gains'][self.to_pe==0] = 0
 

--- a/wfsim/strax_interface.py
+++ b/wfsim/strax_interface.py
@@ -280,6 +280,11 @@ class ChunkRawRecords(object):
     strax.Option('to_pe_file', 
                  default='https://raw.githubusercontent.com/XENONnT/'
                  'strax_auxiliary_files/master/to_pe.npy'),
+    strax.Option('gain_model',
+                 default=('to_pe_per_run',
+                 'https://raw.githubusercontent.com/XENONnT/'
+                 'strax_auxiliary_files/master/to_pe.npy'),
+                 help='PMT gain model. Specify as (model_type, model_config)'),
     strax.Option('right_raw_extension', default=50000),
     strax.Option('zle_threshold', default=0),
     strax.Option('detector',default='XENON1T', track=True),

--- a/wfsim/strax_interface.py
+++ b/wfsim/strax_interface.py
@@ -55,7 +55,7 @@ def rand_instructions(c):
     instructions['z'] = np.repeat(np.random.uniform(-100, 0, n), 2)
 
     nphotons = np.random.uniform(2000, 2050, n)
-    nelectrons = 10 ** (np.random.uniform(1, 4, n))
+    nelectrons = 10 ** (np.random.uniform(3, 4, n))
     instructions['amp'] = np.vstack([nphotons, nelectrons]).T.flatten().astype(int)
 
     return instructions

--- a/wfsim/strax_interface.py
+++ b/wfsim/strax_interface.py
@@ -221,7 +221,7 @@ class ChunkRawRecords(object):
         records = records[maska]
 
         records = strax.sort_by_time(records) # Do NOT remove this line
-        strax.baseline(records)
+        # strax.baseline(records) Will be done w/ pulse processing
         strax.integrate(records)
 
         # Yield an appropriate amount of stuff from the truth buffer

--- a/wfsim/strax_interface.py
+++ b/wfsim/strax_interface.py
@@ -276,7 +276,7 @@ class ChunkRawRecords(object):
                  help="Number of chunks to simulate"),
     strax.Option('fax_config', 
                  default='https://raw.githubusercontent.com/XENONnT/'
-                 'strax_auxiliary_files/master/fax_files/fax_config.json'),
+                 'strax_auxiliary_files/master/fax_files/fax_config_1t.json'),
     strax.Option('to_pe_file', 
                  default='https://raw.githubusercontent.com/XENONnT/'
                  'strax_auxiliary_files/master/to_pe.npy'),

--- a/wfsim/strax_interface.py
+++ b/wfsim/strax_interface.py
@@ -381,11 +381,8 @@ class RawRecordsFromFax(FaxSimulatorPlugin):
             raise RuntimeError("Bug in chunk count computation")
         self._sort_check(result['raw_records'])
 
-        if strax.__version__ >= '0.9.0':
-            return {data_type:self.chunk(
-                start=self.sim.chunk_time_pre,
-                end=self.sim.chunk_time,
-                data=result[data_type],
-                data_type=data_type) for data_type in self.provides}
-        else:
-            return result
+        return {data_type:self.chunk(
+            start=self.sim.chunk_time_pre,
+            end=self.sim.chunk_time,
+            data=result[data_type],
+            data_type=data_type) for data_type in self.provides}

--- a/wfsim/strax_interface.py
+++ b/wfsim/strax_interface.py
@@ -319,12 +319,12 @@ class FaxSimulatorPlugin(strax.Plugin):
         else:
             self.instructions = rand_instructions(c)
 
-        assert (np.all(self.instructions['x']**2 + self.instructions['y']**2 < 2500),
-                "Interation is outside the TPC")
-        assert (np.all(self.instructions['z'] < 0.25) & np.all(self.instructions['z'] > -100),
-                "Interation is outside the TPC")
-        assert (np.all(self.instructions['amp'] > 0),
-                "Interaction has zero size")
+        assert np.all(self.instructions['x']**2 + self.instructions['y']**2 < 2500), \
+                "Interation is outside the TPC"
+        assert np.all(self.instructions['z'] < 0.25) & np.all(self.instructions['z'] > -100), \
+                "Interation is outside the TPC"
+        assert np.all(self.instructions['amp'] > 0), \
+                "Interaction has zero size"
 
     def _sort_check(self, result):
         if result['time'][0] < self.last_chunk_time + 1000:


### PR DESCRIPTION
The strax has updated to [v0.9.0](https://github.com/AxFoundation/strax/releases/tag/v0.9.0), requiring 
chunk class (dictionary of chunk classes) for return.

Other updates:
  - Remove gains from config, instead use to_pe file to calculate gain.
  - Add the secondary signal from the photo-electric effect of the gate, only for S2. Matching S2 pulse shape by eye.
  - Fix some issues with truth output when there're dead pmts.
  - Update pax_interface so it can work again.