### PR TITLE
Add field distortion effects w/ FDC map

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+git+git://github.com/AxFoundation/strax
 git+git://github.com/XENONnT/straxen
 uproot
 nestpy

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open('HISTORY.md') as file:
 
 setuptools.setup(
     name='wfsim',
-    version='0.0.4',
+    version='0.0.4.1',
     description='XENONnT Waveform simulator',
     author='Wfsim contributors, the XENON collaboration',
     url='https://github.com/XENONnT/wfsim',

--- a/wfsim/__init__.py
+++ b/wfsim/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.0.4'
+__version__ = '0.0.4.1'
 
 from .core import *
 from .strax_interface import *

--- a/wfsim/core.py
+++ b/wfsim/core.py
@@ -801,10 +801,10 @@ class RawData(object):
         # Any additional fields in instruction correspond to temporary
         # configuration overrides. No need to restore the old config:
         # next instruction cannot but contain the same fields.
-        if len(instruction) > 8:
+        if len(instruction.dtype.names) > 8:
             for par in instruction.dtype.names:
                 if par in self.config:
-                    self.config[par] = instruction[par]
+                    self.config[par] = instruction[par][0]
 
         # Simulate the primary pulse
         primary_pulse = self.symtype(instruction['type'][0])

--- a/wfsim/core.py
+++ b/wfsim/core.py
@@ -352,7 +352,9 @@ class S2(Pulse):
                 positions = np.array([x_obs, y_obs, z_obs]).T # Switch to observe pos in next iter
 
             positions = np.array([x_obs, y_obs]).T  # For map interpolation
-            z = z_obs
+        else:
+            z_obs = z
+            positions = np.array([x, y]).T  # For map interpolation
 
         if self.config['detector'] == 'XENONnT':
             #Light yield map crashes, but the result is 1 for all positions in the tpc
@@ -361,7 +363,7 @@ class S2(Pulse):
             sc_gain = self.resource.s2_light_yield_map(positions) * self.config['s2_secondary_sc_gain']
 
         # Average drift time of the electrons
-        self.drift_time_mean = - z / \
+        self.drift_time_mean = - z_obs / \
             self.config['drift_velocity_liquid'] + self.config['drift_time_gate']
 
         # Absorb electrons during the drift
@@ -375,7 +377,7 @@ class S2(Pulse):
         n_electron = np.random.binomial(n=n_electron, p=cy)
 
         # Second generate photon timing and channel
-        self.photon_timings(t, n_electron, z, sc_gain)
+        self.photon_timings(t, n_electron, z_obs, sc_gain)
         self.photon_channels(positions)
 
         super().__call__()

--- a/wfsim/core.py
+++ b/wfsim/core.py
@@ -338,20 +338,21 @@ class S2(Pulse):
             np.array(v).reshape(-1) for v in zip(*instruction)]
         
         # Reverse engineerring FDC
-        positions = np.array([x, y, z]).T
-        for i_iter in range(6): # 6 Seems to work
-            dr = self.resource.fdc_3d(positions)
-            if i_iter > 0: dr = 0.5 * dr + 0.5 * dr_pre # Average between iter
-            dr_pre = dr
+        if self.config['field_distortion_on']:
+            positions = np.array([x, y, z]).T
+            for i_iter in range(6): # 6 Seems to work
+                dr = self.resource.fdc_3d(positions)
+                if i_iter > 0: dr = 0.5 * dr + 0.5 * dr_pre # Average between iter
+                dr_pre = dr
 
-            r_obs = np.sqrt(x**2 + y**2) - dr
-            x_obs = x * r_obs / (r_obs + dr)
-            y_obs = y * r_obs / (r_obs + dr)
-            z_obs = - np.sqrt(z**2 + dr**2)
-            positions = np.array([x_obs, y_obs, z_obs]).T # Switch to observe pos in next iter
+                r_obs = np.sqrt(x**2 + y**2) - dr
+                x_obs = x * r_obs / (r_obs + dr)
+                y_obs = y * r_obs / (r_obs + dr)
+                z_obs = - np.sqrt(z**2 + dr**2)
+                positions = np.array([x_obs, y_obs, z_obs]).T # Switch to observe pos in next iter
 
-        positions = np.array([x_obs, y_obs]).T  # For map interpolation
-        
+            positions = np.array([x_obs, y_obs]).T  # For map interpolation
+
         if self.config['detector'] == 'XENONnT':
             #Light yield map crashes, but the result is 1 for all positions in the tpc
             sc_gain = np.repeat(self.config['s2_secondary_sc_gain'], len(positions))

--- a/wfsim/core.py
+++ b/wfsim/core.py
@@ -336,8 +336,22 @@ class S2(Pulse):
 
         _, _, t, x, y, z, n_electron, recoil_type, *rest = [
             np.array(v).reshape(-1) for v in zip(*instruction)]
+        
+        # Reverse engineerring FDC
+        positions = np.array([x, y, z]).T
+        for i_iter in range(6): # 6 Seems to work
+            dr = self.resource.fdc_3d(positions)
+            if i_iter > 0: dr = 0.5 * dr + 0.5 * dr_pre # Average between iter
+            dr_pre = dr
 
-        positions = np.array([x, y]).T  # For map interpolation
+            r_obs = np.sqrt(x**2 + y**2) - dr
+            x_obs = x * r_obs / (r_obs + dr)
+            y_obs = y * r_obs / (r_obs + dr)
+            z_obs = - np.sqrt(z**2 + dr**2)
+            positions = np.array([x_obs, y_obs, z_obs]).T # Switch to observe pos in next iter
+
+        positions = np.array([x_obs, y_obs]).T  # For map interpolation
+        
         if self.config['detector'] == 'XENONnT':
             #Light yield map crashes, but the result is 1 for all positions in the tpc
             sc_gain = np.repeat(self.config['s2_secondary_sc_gain'], len(positions))
@@ -345,7 +359,7 @@ class S2(Pulse):
             sc_gain = self.resource.s2_light_yield_map(positions) * self.config['s2_secondary_sc_gain']
 
         # Average drift time of the electrons
-        self.drift_time_mean = - z / \
+        self.drift_time_mean = - z_obs / \
             self.config['drift_velocity_liquid'] + self.config['drift_time_gate']
 
         # Absorb electrons during the drift
@@ -359,7 +373,7 @@ class S2(Pulse):
         n_electron = np.random.binomial(n=n_electron, p=cy)
 
         # Second generate photon timing and channel
-        self.photon_timings(t, n_electron, z, sc_gain)
+        self.photon_timings(t, n_electron, z_obs, sc_gain)
         self.photon_channels(positions)
 
         super().__call__()

--- a/wfsim/core.py
+++ b/wfsim/core.py
@@ -352,6 +352,7 @@ class S2(Pulse):
                 positions = np.array([x_obs, y_obs, z_obs]).T # Switch to observe pos in next iter
 
             positions = np.array([x_obs, y_obs]).T  # For map interpolation
+            z = z_obs
 
         if self.config['detector'] == 'XENONnT':
             #Light yield map crashes, but the result is 1 for all positions in the tpc
@@ -360,7 +361,7 @@ class S2(Pulse):
             sc_gain = self.resource.s2_light_yield_map(positions) * self.config['s2_secondary_sc_gain']
 
         # Average drift time of the electrons
-        self.drift_time_mean = - z_obs / \
+        self.drift_time_mean = - z / \
             self.config['drift_velocity_liquid'] + self.config['drift_time_gate']
 
         # Absorb electrons during the drift
@@ -374,7 +375,7 @@ class S2(Pulse):
         n_electron = np.random.binomial(n=n_electron, p=cy)
 
         # Second generate photon timing and channel
-        self.photon_timings(t, n_electron, z_obs, sc_gain)
+        self.photon_timings(t, n_electron, z, sc_gain)
         self.photon_channels(positions)
 
         super().__call__()

--- a/wfsim/load_resource.py
+++ b/wfsim/load_resource.py
@@ -42,6 +42,7 @@ class Resource:
                 's2_pattern_map': 'XENON1T_s2_xy_patterns_top_corrected_MCv2.1.0.json.gz',
                 's2_per_pmt_params': 'Kr83m_Ddriven_per_pmt_params_dataframe.csv',
                 'photon_ap_cdfs': 'x1t_pmt_afterpulse_config.pkl.gz',
+                'fdc_3d': 'XENON1T_FDC_SR1_data_driven_time_dependent_3d_correction_tf_nn_part1_v1.json.gz',
             })
         elif config['detector'] == 'XENONnT':
             files.update({
@@ -70,6 +71,7 @@ class Resource:
             self.s1_light_yield_map = make_map(files['s1_light_yield_map'], fmt='json')
             self.s2_light_yield_map = make_map(files['s2_light_yield_map'], fmt='json')
             self.s2_per_pmt_params = straxen.get_resource(files['s2_per_pmt_params'], fmt='csv')
+            self.fdc_3d = make_map(files['fdc_3d'], fmt='json.gz')
 
         if config['detector'] == 'XENONnT':
             self.s1_pattern_map = make_map(files['s1_pattern_map'], fmt='pkl')
@@ -81,6 +83,7 @@ class Resource:
             lymap = deepcopy(self.s2_pattern_map)
             lymap.data['map'] = np.sum(lymap.data['map'][:][:], axis=2)
             self.s2_light_yield_map = lymap
+            self.fdc_3d = dummy_map(result=0)
 
         # Electron After Pulses compressed, haven't figure out how pkl.gz works
         self.uniform_to_ele_ap = straxen.get_resource(files['ele_ap_pdfs'], fmt='pkl.gz')
@@ -95,3 +98,9 @@ class Resource:
 def make_map(map_file: str, fmt='text'):
     map_data = straxen.get_resource(map_file, fmt)
     return straxen.InterpolatingMap(map_data)
+
+class dummy_map():
+    def __init__(self, result):
+        self.result = result
+    def __call__(self, positions):
+        return np.ones(positions.shape[0]) * self.result

--- a/wfsim/pax_interface.py
+++ b/wfsim/pax_interface.py
@@ -23,7 +23,7 @@ class PaxEvents(object):
         self.config = config
         self.rawdata = RawData(self.config)
         
-        self.truth_buffer = np.zeros(10000, dtype=instruction_dtype + truth_extra_dtype + [('fill', bool)]) # 500 s1 + 500 s2
+        self.truth_buffer = np.zeros(100000, dtype=instruction_dtype + truth_extra_dtype + [('fill', bool)]) # 500 s1 + 500 s2
 
     def __call__(self, instructions):
         event_i = 0 # Indices of event

--- a/wfsim/pax_interface.py
+++ b/wfsim/pax_interface.py
@@ -62,6 +62,7 @@ EventProxy = namedtuple('EventProxy', ['data', 'event_number', 'block_id'])
 default_config = {
     'fax_file':None,
     'detector':'XENON1T',
+    'field_distortion_on':True,
     'event_rate':1, # Must set to one so chunk can be interpret as an event
     'chunk_size':1, # Must set to one so chunk can be interpret as an event
     'nchunk':200, # Number of events

--- a/wfsim/strax_interface.py
+++ b/wfsim/strax_interface.py
@@ -287,7 +287,8 @@ class ChunkRawRecords(object):
                  help='PMT gain model. Specify as (model_type, model_config)'),
     strax.Option('right_raw_extension', default=50000),
     strax.Option('zle_threshold', default=0),
-    strax.Option('detector',default='XENON1T', track=True),
+    strax.Option('detector', default='XENON1T', track=True),
+    strax.Option('field_distortion_on', default=False, track=True),
     strax.Option('timeout', default=1800,
                  help="Terminate processing if any one mailbox receives "
                       "no result for more than this many seconds"))


### PR DESCRIPTION
Adding field distortion feature to core simulation.

Use SR1 nn tf part 1 for xenon1t
Return 0 correction for xenonnt

The results are shown below, observed positions with given points on a circle with r=[10, 20... 50]. The observed positions are stable after a few iterations, (as fdc map is not asking true position as input), more solid color represents later in the iteration (max=6)
![image](https://user-images.githubusercontent.com/16232525/79955126-549a4a00-844c-11ea-925f-5e6ea7b3b35b.png)

Other fixes along with this pr:
Increase pax_interface truth buffer size,  because unlike strax, it's not being copied and cleared at the end of each chunk.

Check the length of instruction dtype names instead of instruction itself for extra columns, as now instruction is a structured array by default.
