### PR TITLE
Update for instructions from optical mc

### DIFF
--- a/wfsim/__init__.py
+++ b/wfsim/__init__.py
@@ -3,3 +3,4 @@ __version__ = '0.0.4.1'
 from .core import *
 from .strax_interface import *
 from .pax_interface import *
+from .raw_optical import *

--- a/wfsim/core.py
+++ b/wfsim/core.py
@@ -79,7 +79,7 @@ class Pulse(object):
                 else:
                     _channel_photon_gains = self.config['gains'][channel] \
                     * self.uniform_to_pe_arr[0](np.random.random(len(_channel_photon_timings)))
-                    
+
                 # Add some double photoelectron emission by adding another sampled gain
                 n_double_pe = np.random.binomial(len(_channel_photon_timings),
                                                  p=self.config['p_double_pe_emision'])
@@ -996,3 +996,7 @@ class RawData(object):
         result = data[id_t:id_t + length]
 
         return result
+
+
+
+

--- a/wfsim/raw_optical.py
+++ b/wfsim/raw_optical.py
@@ -1,0 +1,189 @@
+import numpy as np
+from tqdm import tqdm
+
+from .load_resource import load_config
+from strax import exporter
+import wfsim
+export, __all__ = exporter()
+
+
+@export
+class RawDataOptical(wfsim.RawData):
+
+    def __init__(self, config):
+        self.config = config
+        self.pulses = wfsim.Pulse(config)
+        self.resource = load_config(self.config)
+
+    def __call__(self, instructions, channels, timings, truth_buffer=None):
+        if truth_buffer is None:
+            truth_buffer = []
+
+        rext = self.config['right_raw_extension']
+
+        # Data cache
+        self._pulses_cache = []
+        self._raw_data_cache = []
+
+        # Iteration conditions
+        self.source_finished = False
+        self.last_pulse_end_time = - np.inf
+        self.instruction_event_number = np.min(instructions['event_number'])
+
+        # Primary instructions must be sorted by signal time
+        # int(type) by design S1-esque being odd, S2-esque being even
+        # thus type%2-1 is 0:S1-esque;  -1:S2-esque
+        # Make a list of clusters of instructions, with gap smaller then rext
+        inst_time = instructions['time']
+        inst_queue = np.argsort(inst_time)
+        inst_queue = np.split(inst_queue, np.where(np.diff(inst_time[inst_queue]) > rext)[0]+1)
+
+        # Instruction buffer
+        instb = np.zeros(100000, dtype=instructions.dtype)  # size ~ 1% of size of primary
+        instb_filled = np.zeros_like(instb, dtype=bool)  # Mask of where buffer is filled
+
+        # ik those are illegible, messy logic. lmk if you have a better way
+        pbar = tqdm(total=len(inst_queue), desc='Simulating Raw Records')
+        while not self.source_finished:
+
+            # A) Add a new instruction into buffer
+            try:
+                ixs = inst_queue.pop(0)  # The index from original instruction list
+                self.source_finished = len(inst_queue) == 0
+                assert len(np.where(~instb_filled)[0]) > len(ixs), "Run out of instruction buffer"
+                ib = np.where(~instb_filled)[0][:len(ixs)]  # The index of first empty slot in buffer
+                instb[ib] = instructions[ixs]
+                instb_filled[ib] = True
+                pbar.update(1)
+            except:
+                pass
+
+            # B) Cluster instructions again with gap size <= rext
+            instb_indx = np.where(instb_filled)[0]
+            instb_type = instb[instb_indx]['type']
+            instb_time = instb[instb_indx]['time']
+            instb_queue = np.argsort(instb_time, kind='stable')
+            instb_queue = np.split(instb_queue,
+                                   np.where(np.diff(instb_time[instb_queue]) > rext)[0] + 1)
+
+            # C) Push pulse cache out first if nothing comes right after them
+            if np.min(instb_time) - self.last_pulse_end_time > rext and not np.isinf(self.last_pulse_end_time):
+                self.digitize_pulse_cache()
+                yield from self.ZLE()
+
+            # D) Run all clusters before the current source
+            stop_at_this_group = False
+            for ibqs in instb_queue:
+                for ptype in [1, 2]:  # S1 S2 PI Gate
+                    mask = instb_type[ibqs] == ptype
+                    if np.sum(mask) == 0: continue  # No such instruction type
+                    instb_run = instb_indx[ibqs[mask]]  # Take hold of todo list
+
+                    if self.symtype(ptype) in ['s1', 's2']:
+                        stop_at_this_group = True  # Stop group iteration
+                        _instb_run = np.array_split(instb_run, len(instb_run))
+                    else:
+                        _instb_run = [instb_run]  # Small trick to make truth small
+
+                    # Run pulse simulation for real
+                    for instb_run in _instb_run:
+                        for instb_secondary in self.sim_data(instb[instb_run],
+                                                             channels[instb[instb_run]['event_number'][0]],
+                                                             instb[instb_run]['time'] + timings[instb[instb_run]['event_number'][0]]):
+                            ib = np.where(~instb_filled)[0][:len(instb_secondary)]
+                            instb[ib] = instb_secondary
+                            instb_filled[ib] = True
+
+                        if len(truth_buffer):  # Extract truth info
+                            self.get_truth(instb[instb_run], truth_buffer)
+
+                        instb_filled[instb_run] = False  # Free buffer AFTER copyting into truth buffer
+
+                if stop_at_this_group: break
+                self.digitize_pulse_cache()  # from pulse cache to raw data
+                yield from self.ZLE()
+
+            self.source_finished = len(inst_queue) == 0 and np.sum(instb_filled) == 0
+        pbar.close()
+
+    def sim_data(self, instruction, channels, timings):
+        """Simulate a pulse according to instruction, and yield any additional instructions
+        for secondary electron afterpulses.
+        """
+        # Any additional fields in instruction correspond to temporary
+        # configuration overrides. No need to restore the old config:
+        # next instruction cannot but contain the same fields.
+
+        # Simulate the primary pulse
+        self.pulses._photon_channels = channels
+        self.pulses._photon_timings = timings
+        self.pulses()
+
+        # Append pulses we just simulated to our cache
+        _pulses = getattr(self.pulses, '_pulses')
+        if len(_pulses) > 0:
+            self._pulses_cache += _pulses
+            self.last_pulse_end_time = max(
+                self.last_pulse_end_time,
+                np.max([p['right'] for p in _pulses]) * 10)
+        return []
+
+    def get_truth(self, instruction, truth_buffer):
+        """Write truth in the first empty row of truth_buffer
+
+        :param instruction: Array of instructions that were simulated as a
+        single cluster, and should thus get one line in the truth info.
+        :param truth_buffer: Truth buffer to write in.
+        """
+        ix = np.argmin(truth_buffer['fill'])
+        tb = truth_buffer[ix]
+        peak_type = self.symtype(instruction['type'][0])
+        pulse = self.pulses
+
+        for quantum in 'photon', 'electron':
+            times = getattr(pulse, f'_{quantum}_timings', [])
+            # Set an endtime (if times has no length)
+            tb['endtime'] = np.mean(instruction['time'])
+            if len(times):
+                tb[f'n_{quantum}'] = len(times)
+                tb[f't_mean_{quantum}'] = np.mean(times)
+                tb[f't_first_{quantum}'] = np.min(times)
+                tb[f't_last_{quantum}'] = np.max(times)
+                tb[f't_sigma_{quantum}'] = np.std(times)
+                tb['endtime'] = tb['t_last_photon']
+            else:
+                # Peak does not have photons / electrons
+                # zero-photon afterpulses can be removed from truth info
+                if peak_type not in ['s1', 's2'] and quantum == 'photon':
+                    return
+                tb[f'n_{quantum}'] = 0
+                tb[f't_mean_{quantum}'] = np.nan
+                tb[f't_first_{quantum}'] = np.nan
+                tb[f't_last_{quantum}'] = np.nan
+                tb[f't_sigma_{quantum}'] = np.nan
+
+        channels = getattr(pulse, '_photon_channels', [])
+        n_dpe = getattr(pulse, '_n_double_pe', 0)
+        n_dpe_bot = getattr(pulse, '_n_double_pe_bot', 0)
+        tb['n_photon'] += n_dpe
+        tb['n_photon'] -= np.sum(np.isin(channels, getattr(pulse, 'turned_off_pmts', [])))
+
+        channels_bottom = list(
+            set(self.config['channels_bottom']).difference(getattr(pulse, 'turned_off_pmts', [])))
+        tb['n_photon_bottom'] = (
+            np.sum(np.isin(channels, channels_bottom))
+            + n_dpe_bot)
+
+        # Summarize the instruction cluster in one row of the truth file
+        for field in instruction.dtype.names:
+            value = instruction[field]
+            if len(instruction) > 1 and field in 'txyz':
+                tb[field] = np.mean(value)
+            elif len(instruction) > 1 and field == 'amp':
+                tb[field] = np.sum(value)
+            else:
+                # Cannot summarize intelligently: just take the first value
+                tb[field] = value[0]
+
+        # Signal this row is now filled, so it won't be overwritten
+        tb['fill'] = True

--- a/wfsim/strax_interface.py
+++ b/wfsim/strax_interface.py
@@ -355,7 +355,7 @@ class ChunkRawRecordsOptical(ChunkRawRecords):
 
 
 @strax.takes_config(
-    strax.Option('optical',default=True, track=True,
+    strax.Option('optical',default=False, track=True,
                  help="Flag for using optical mc for instructions"),
     strax.Option('fax_file', default=None, track=True,
                  help="Directory with fax instructions"),

--- a/wfsim/strax_interface.py
+++ b/wfsim/strax_interface.py
@@ -8,8 +8,7 @@ import pandas as pd
 import strax
 from straxen.common import get_resource
 from straxen import get_to_pe
-
-from .core import RawData
+import wfsim
 
 export, __all__ = strax.exporter()
 __all__ += ['instruction_dtype', 'truth_extra_dtype']
@@ -59,6 +58,42 @@ def rand_instructions(c):
     instructions['amp'] = np.vstack([nphotons, nelectrons]).T.flatten().astype(int)
 
     return instructions
+
+
+@export
+def read_optical(file):
+    data = uproot.open(file)
+    all_ttrees = dict(data.allitems(filterclass=lambda cls: issubclass(cls, uproot.tree.TTreeMethods)))
+    e = all_ttrees[b'events/events;1']
+
+    n_events = len(e.array('eventid'))
+    # lets separate the events in time by a constant time difference
+    time = np.arange(1, n_events+1)
+
+    # Events should be in the TPC
+    xp = e.array("xp_pri") / 10
+    yp = e.array("xp_pri") / 10
+    zp = e.array("xp_pri") / 10
+
+    channels = e.array("pmthitID")
+    timings = e.array("pmthitTime")*1e9
+
+    ins = np.zeros(n_events, dtype=instruction_dtype)
+
+    ins['x'], ins['y'], ins['z'], ins['time'] = xp.flatten()  / 10, \
+                                                       yp.flatten() / 10, \
+                                                       zp.flatten() / 10, \
+                                                       1e7 * time.flatten()
+
+    ins['event_number'] = np.arange(n_events)
+    ins['type'] = np.repeat(1, n_events)
+    ins['recoil'] = np.repeat('er', n_events)
+    ins['amp'] = [len(t) for t in timings]
+
+    # cut interactions without electrons or photons
+    ins = ins[ins["amp"] > 0]
+
+    return ins, channels, timings
 
 
 @export
@@ -162,7 +197,7 @@ def instruction_from_csv(filename):
 class ChunkRawRecords(object):
     def __init__(self, config):
         self.config = config
-        self.rawdata = RawData(self.config)
+        self.rawdata = wfsim.RawData(self.config)
         self.record_buffer = np.zeros(5000000, dtype=strax.record_dtype()) # 2*250 ms buffer
         self.truth_buffer = np.zeros(10000, dtype=instruction_dtype + truth_extra_dtype + [('fill', bool)])
 
@@ -178,7 +213,6 @@ class ChunkRawRecords(object):
         self.chunk_time_pre = np.min(instructions['time']) - rext
         self.chunk_time = self.chunk_time_pre + cksz # Starting chunk
         self.current_digitized_right = self.last_digitized_right = 0
-
         for channel, left, right, data in self.rawdata(instructions, self.truth_buffer):
             pulse_length = right - left + 1
             records_needed = int(np.ceil(pulse_length / samples_per_record))
@@ -263,7 +297,69 @@ class ChunkRawRecords(object):
         return self.rawdata.source_finished
 
 
+@export
+class ChunkRawRecordsOptical(ChunkRawRecords):
+    def __init__(self, config):
+        self.config = config
+        self.rawdata = wfsim.RawDataOptical(self.config)
+        self.record_buffer = np.zeros(5000000, dtype=strax.record_dtype()) # 2*250 ms buffer
+        self.truth_buffer = np.zeros(10000, dtype=instruction_dtype + truth_extra_dtype + [('fill', bool)])
+
+    def __call__(self, instructions, channels, timings):
+        # Save the constants as privates
+        samples_per_record = strax.DEFAULT_RECORD_LENGTH
+        buffer_length = len(self.record_buffer)
+        dt = self.config['sample_duration']
+        rext = int(self.config['right_raw_extension'])
+        cksz = int(self.config['chunk_size'] * 1e9)
+
+        self.blevel = buffer_filled_level = 0
+        self.chunk_time_pre = np.min(instructions['time']) - rext
+        self.chunk_time = self.chunk_time_pre + cksz # Starting chunk
+        self.current_digitized_right = self.last_digitized_right = 0
+        for channel, left, right, data in self.rawdata(instructions, channels, timings, self.truth_buffer):
+            pulse_length = right - left + 1
+            records_needed = int(np.ceil(pulse_length / samples_per_record))
+
+            if self.rawdata.left * self.config['sample_duration'] > self.chunk_time:
+                self.chunk_time = self.last_digitized_right * self.config['sample_duration']
+                yield from self.final_results()
+                self.chunk_time_pre = self.chunk_time
+                self.chunk_time += cksz
+
+            if self.blevel + records_needed > buffer_length:
+                log.warning('Chunck size too large, insufficient record buffer')
+                yield from self.final_results()
+
+            if self.blevel + records_needed > buffer_length:
+                log.warning('Pulse length too large, insufficient record buffer, skipping pulse')
+                continue
+
+            # WARNING baseline and area fields are zeros before finish_results
+            s = slice(self.blevel, self.blevel + records_needed)
+            self.record_buffer[s]['channel'] = channel
+            self.record_buffer[s]['dt'] = dt
+            self.record_buffer[s]['time'] = dt * (left + samples_per_record * np.arange(records_needed))
+            self.record_buffer[s]['length'] = [min(pulse_length, samples_per_record * (i+1))
+                - samples_per_record * i for i in range(records_needed)]
+            self.record_buffer[s]['pulse_length'] = pulse_length
+            self.record_buffer[s]['record_i'] = np.arange(records_needed)
+            self.record_buffer[s]['data'] = np.pad(data,
+                (0, records_needed * samples_per_record - pulse_length), 'constant').reshape((-1, samples_per_record))
+            self.blevel += records_needed
+
+            if self.rawdata.right != self.current_digitized_right:
+                self.last_digitized_right = self.current_digitized_right
+                self.current_digitized_right = self.rawdata.right
+
+        yield from self.final_results()
+
+
+
+
 @strax.takes_config(
+    strax.Option('optical',default=True, track=True,
+                 help="Flag for using optical mc for instructions"),
     strax.Option('fax_file', default=None, track=True,
                  help="Directory with fax instructions"),
     strax.Option('fax_config_override', default=None,
@@ -313,7 +409,7 @@ class FaxSimulatorPlugin(strax.Plugin):
         c = self.config
         c.update(get_resource(c['fax_config'], fmt='json'))
         # Update gains to the nT defaults
-        self.to_pe = get_to_pe(self.run_id, ('to_pe_per_run',self.config['to_pe_file']),
+        self.to_pe = get_to_pe(self.run_id, c['gain_model'],
                               len(c['channels_in_detector']['tpc']))
         c['gains'] = 1 / self.to_pe * (1e-8 * 2.25 / 2**14) / (1.6e-19 * 10 * 50)
         c['gains'][self.to_pe==0] = 0
@@ -322,7 +418,11 @@ class FaxSimulatorPlugin(strax.Plugin):
         if overrides is not None:
             c.update(overrides)
 
-        if c['fax_file']:
+        if c['optical']:
+            self.instructions, self.channels, self.timings = read_optical(c['fax_file'])
+            c['nevents']=len(self.instructions['event_number'])
+
+        elif c['fax_file']:
             if c['fax_file'][-5:] == '.root':
                 self.instructions = read_g4(c['fax_file'])
                 c['nevents'] = np.max(self.instructions['event_number'])
@@ -333,12 +433,12 @@ class FaxSimulatorPlugin(strax.Plugin):
         else:
             self.instructions = rand_instructions(c)
 
-        assert np.all(self.instructions['x']**2 + self.instructions['y']**2 < 2500), \
-                "Interation is outside the TPC"
-        assert np.all(self.instructions['z'] < 0.25) & np.all(self.instructions['z'] > -100), \
-                "Interation is outside the TPC"
-        assert np.all(self.instructions['amp'] > 0), \
-                "Interaction has zero size"
+        # assert np.all(self.instructions['x']**2 + self.instructions['y']**2 < 2500), \
+        #         "Interation is outside the TPC"
+        # assert np.all(self.instructions['z'] < 0.25) & np.all(self.instructions['z'] > -100), \
+        #         "Interation is outside the TPC"
+        # assert np.all(self.instructions['amp'] > 0), \
+        #         "Interaction has zero size"
 
     def _sort_check(self, result):
         if len(result) == 0: return
@@ -392,3 +492,15 @@ class RawRecordsFromFax(FaxSimulatorPlugin):
             end=self.sim.chunk_time,
             data=result[data_type],
             data_type=data_type) for data_type in self.provides}
+
+
+@export
+# @strax.takes_config(
+#     strax.Option('optical', default=True, track=True,
+#                  help="Flag for using optical mc for instructions"),)
+class RawRecordsFromFaxOptical(RawRecordsFromFax):
+
+    def setup(self):
+        super().setup()
+        self.sim = ChunkRawRecordsOptical(self.config)
+        self.sim_iter = self.sim(self.instructions, self.channels, self.timings)


### PR DESCRIPTION
This pull request adds:
  *  Adds the option of using optical mc data to use as instructions for simulation

To use register wfsim.RawRecordsFromFaxOptical and set the context option "optical" to True

There is still quite some needlessly double code in here. So I'll need to clean it up more