### PR TITLE
Adding features needed to support high energy channels for XENONnT simulations

### DIFF
--- a/notebooks/Fax_Tutorial.ipynb
+++ b/notebooks/Fax_Tutorial.ipynb
@@ -48,8 +48,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "First we need to define the right context. The thing which differs now is where to get the plugin to provide raw records. By default this is the DAQ Reader. Now we do not want this so we register wfsim.RawRecordsFromFax. I think it is self explanatory where this plugin tells strax to get raw records from.\n",
-    "Through a config option in the context you can specify if you want a 1T or nT configuration"
+    "First we need to define the right context. The thing which differs now is where to get the plugin to provide raw records. By default this is the DAQ Reader. Depending on which detector you want (1T or nT) we have two different plugins you'll need to register. One is RawRecordsFromFax1T, the other RawRecordsFromFaxNT."
    ]
   },
   {
@@ -67,8 +66,10 @@
    "source": [
     "st = strax.Context(\n",
     "        storage=strax.DataDirectory('./strax_data'),\n",
-    "        register=wfsim.RawRecordsFromFax,\n",
+    "        register=wfsim.RawRecordsFromFax1T,\n",
     "        config=dict(detector='XENON1T',\n",
+    "                    fax_config='https://raw.githubusercontent.com/XENONnT/'\n",
+    "                               'strax_auxiliary_files/master/fax_files/fax_config_1t.json',\n",
     "                    **straxen.contexts.x1t_common_config),\n",
     "        **straxen.contexts.common_opts)"
    ]
@@ -88,15 +89,45 @@
    "source": [
     "st = strax.Context(\n",
     "        storage=strax.DataDirectory('./strax_data'),\n",
-    "        register=wfsim.RawRecordsFromFax,\n",
+    "        register=wfsim.RawRecordsFromFaxNT,\n",
     "        config=dict(detector='XENONnT',\n",
-    "                    to_pe_file= 'https://raw.githubusercontent.com/XENONnT/'\n",
-    "                                   'strax_auxiliary_files/master/fax_files/to_pe_nt.npy',\n",
     "                    fax_config='https://raw.githubusercontent.com/XENONnT/'\n",
     "                               'strax_auxiliary_files/master/fax_files/fax_config_nt.json',\n",
     "                    **straxen.contexts.xnt_common_config,),\n",
-    "        timeout= 3600,\n",
     "        **straxen.contexts.common_opts)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To make your life even simpler there is currently a pull request open to add these to the default straxen contexts.\n",
+    "As soon as they get merged you can also do:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "st = straxen.contexts.xenon1t_simulation()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "or"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "st = straxen.contexts.xenonnt_simulation()"
    ]
   },
   {

--- a/notebooks/Fax_Tutorial.ipynb
+++ b/notebooks/Fax_Tutorial.ipynb
@@ -70,7 +70,7 @@
     "        config=dict(detector='XENON1T',\n",
     "                    fax_config='https://raw.githubusercontent.com/XENONnT/'\n",
     "                               'strax_auxiliary_files/master/fax_files/fax_config_1t.json',\n",
-    "                    **straxen.contexts.x1t_common_config),\n",
+    "                    **straxen.contexts.x1t_common_config,),\n",
     "        **straxen.contexts.common_opts)"
    ]
   },
@@ -93,7 +93,9 @@
     "        config=dict(detector='XENONnT',\n",
     "                    fax_config='https://raw.githubusercontent.com/XENONnT/'\n",
     "                               'strax_auxiliary_files/master/fax_files/fax_config_nt.json',\n",
-    "                    **straxen.contexts.xnt_common_config,),\n",
+    "                    **straxen.contexts.xnt_common_config,\n",
+    "                    gain_model=('to_pe_per_run',\n",
+    "                'https://raw.githubusercontent.com/XENONnT/strax_auxiliary_files/master/to_pe_nt.npy'),),\n",
     "        **straxen.contexts.common_opts)"
    ]
   },

--- a/wfsim/core.py
+++ b/wfsim/core.py
@@ -883,12 +883,13 @@ class RawData(object):
                 self._raw_data[_pulse['channel'],
                     _pulse['left'] - self.left:_pulse['right'] - self.left + 1] += adc_wave
                 if self.config['detector'] == 'XENONnT':
+                    adc_wave_he = (adc_wave * self.config[
+                            'high_energy_deamplification_factor']).astype(int)
                     if ix in self.config['channels_top']:
                         self._raw_data[self.config['channels_top_high_energy'][ix],
-                        _pulse['left'] - self.left:_pulse['right'] - self.left + 1] += adc_wave * self.config[
-                            'high_energy_deamplification_factor']
+                        _pulse['left'] - self.left:_pulse['right'] - self.left + 1] += adc_wave_he
                     elif ix in self.config['channels_bottom']:
-                        self.sum_signal(adc_wave * self.config['high_energy_deamplification_factor'],
+                        self.sum_signal(adc_wave_he,
                                    _pulse['left'] - self.left,
                                    _pulse['right'] - self.left + 1,
                                    self._raw_data[self.config['channels_in_detector']['sum_signal']])

--- a/wfsim/core.py
+++ b/wfsim/core.py
@@ -874,7 +874,7 @@ class RawData(object):
 
             # Use noise array to pave the fundation of the pulses
             #self._raw_data = self.get_real_noise(self.right - self.left + 1)
-            self._raw_data = np.zeros((len(self.config['channels_in_detector']['tpc']),
+            self._raw_data = np.zeros((801,
                 self.right - self.left + 1), dtype=('<i8'))
 
             for ix, _pulse in enumerate(self._pulses_cache):
@@ -882,14 +882,24 @@ class RawData(object):
                 adc_wave = - np.trunc(_pulse['current'] * self.current_2_adc).astype(int)
                 self._raw_data[_pulse['channel'],
                     _pulse['left'] - self.left:_pulse['right'] - self.left + 1] += adc_wave
+                if self.config['detector'] == 'XENONnT':
+                    if ix in self.config['channels_top']:
+                        self._raw_data[self.config['channels_top_high_energy'][ix],
+                        _pulse['left'] - self.left:_pulse['right'] - self.left + 1] += adc_wave * self.config[
+                            'high_energy_deamplification_factor']
+                    elif ix in self.config['channels_bottom']:
+                        self.sum_signal(adc_wave * self.config['high_energy_deamplification_factor'],
+                                   _pulse['left'] - self.left,
+                                   _pulse['right'] - self.left + 1,
+                                   self._raw_data[self.config['channels_in_detector']['sum_signal']])
                 
             self._pulses_cache = [] # Memory control
 
             # Digitizers have finite number of bits per channel, so clip the signal.
             self._raw_data += self.config['digitizer_reference_baseline']
             self._raw_data[self._raw_data < 0] = 0
-            # Hopefully (peak downward) waveform won't exceed upper limit
-            # self._raw_data = np.clip(self._raw_data, 0, 2 ** (self.config['digitizer_bits']))
+
+
 
     def ZLE(self):
         """
@@ -996,6 +1006,12 @@ class RawData(object):
         result = data[id_t:id_t + length]
 
         return result
+
+    @staticmethod
+    @njit
+    def sum_signal(adc_wave, left, right, sum_template):
+        sum_template[left:right] += adc_wave
+        return sum_template
 
 
 

--- a/wfsim/strax_interface.py
+++ b/wfsim/strax_interface.py
@@ -294,7 +294,7 @@ class ChunkRawRecords(object):
             yield dict(raw_records=records[records['channel'] < self.config['channels_top_high_energy'][0]],
                        raw_records_he=records[(records['channel'] >= self.config['channels_top_high_energy'][0]) &
                                               (records['channel'] <= self.config['channels_top_high_energy'][-1])],
-                       raw_records_aqmon=records[records['channel]==800],
+                       raw_records_aqmon=records[records['channel']==800],
                        truth=_truth)
         self.record_buffer[:np.sum(~maska)] = self.record_buffer[:self.blevel][~maska]
         self.blevel = np.sum(~maska)

--- a/wfsim/strax_interface.py
+++ b/wfsim/strax_interface.py
@@ -293,8 +293,8 @@ class ChunkRawRecords(object):
         else:
             yield dict(raw_records=records[records['channel'] < self.config['channels_top_high_energy'][0]],
                        raw_records_he=records[(records['channel'] >= self.config['channels_top_high_energy'][0]) &
-                                              (records['channel'] <= self.config['channels_top_high_energy'][-1])]
-                       raw_records_aqmon=records[records['channel]==800]
+                                              (records['channel'] <= self.config['channels_top_high_energy'][-1])],
+                       raw_records_aqmon=records[records['channel]==800],
                        truth=_truth)
         self.record_buffer[:np.sum(~maska)] = self.record_buffer[:self.blevel][~maska]
         self.blevel = np.sum(~maska)

--- a/wfsim/strax_interface.py
+++ b/wfsim/strax_interface.py
@@ -294,7 +294,7 @@ class ChunkRawRecords(object):
             yield dict(raw_records=records[records['channel'] < self.config['channels_top_high_energy'][0]],
                        raw_records_he=records[(records['channel'] >= self.config['channels_top_high_energy'][0]) &
                                               (records['channel'] <= self.config['channels_top_high_energy'][-1])]
-                       aqm_pulses=records[records['channel]==800]
+                       raw_records_aqmon=records[records['channel]==800]
                        truth=_truth)
         self.record_buffer[:np.sum(~maska)] = self.record_buffer[:self.blevel][~maska]
         self.blevel = np.sum(~maska)

--- a/wfsim/strax_interface.py
+++ b/wfsim/strax_interface.py
@@ -292,7 +292,9 @@ class ChunkRawRecords(object):
                        truth=_truth)
         else:
             yield dict(raw_records=records[records['channel'] < self.config['channels_top_high_energy'][0]],
-                       raw_records_he=records[records['channel'] >= self.config['channels_top_high_energy'][0]],
+                       raw_records_he=records[(records['channel'] >= self.config['channels_top_high_energy'][0]) &
+                                              (records['channel'] <= self.config['channels_top_high_energy'][-1])]
+                       aqm_pulses=records[records['channel]==800]
                        truth=_truth)
         self.record_buffer[:np.sum(~maska)] = self.record_buffer[:self.blevel][~maska]
         self.blevel = np.sum(~maska)
@@ -459,7 +461,7 @@ class FaxSimulatorPlugin(strax.Plugin):
 
 @export
 class RawRecordsFromFaxNT(FaxSimulatorPlugin):
-    provides = ('raw_records','raw_records_he', 'truth')
+    provides = ('raw_records','raw_records_he','raw_records_aqmon','truth')
     data_kind = immutabledict(zip(provides, provides))
 
     def setup(self):
@@ -470,6 +472,7 @@ class RawRecordsFromFaxNT(FaxSimulatorPlugin):
     def infer_dtype(self):
         dtype = dict(raw_records=strax.record_dtype(),
                      raw_records_he=strax.record_dtype(),
+                     raw_records_aqmon=strax.record_dtype(),
                      truth=instruction_dtype + truth_extra_dtype)
         return dtype
 

--- a/wfsim/strax_interface.py
+++ b/wfsim/strax_interface.py
@@ -289,11 +289,10 @@ class ChunkRawRecords(object):
             _truth['t_first_photon'][~np.isnan(_truth['t_first_photon'])].astype(int)
         if self.config['detector']=='XENON1T':
             yield dict(raw_records=records,
-                       # raw_records_he= np.zeros(1,dtype=strax.record_dtype()),
                        truth=_truth)
         else:
             yield dict(raw_records=records[records['channel'] < self.config['channels_top_high_energy'][0]],
-                       raw_records_he = records[records['channel'] >= self.config['channels_top_high_energy'][0]],
+                       raw_records_he=records[records['channel'] >= self.config['channels_top_high_energy'][0]],
                        truth=_truth)
         self.record_buffer[:np.sum(~maska)] = self.record_buffer[:self.blevel][~maska]
         self.blevel = np.sum(~maska)


### PR DESCRIPTION
This pull request adds high energy and sum signals.

For this a change needed to be made in the plugins. Since high energy channels are not in XENON1T the plugins for 1T/nT are split off. So to switch between detectors register different plugins rather than setting the detector field as an option.

The sum signal is stored as part of the high energy channels, although it would in reality be part of the aquisition monitor

Note there is a not very pretty hard coded number of channels currently in https://github.com/XENONnT/WFSim/blob/455a481a44bc0ac6926f291e4e2148cb382c00dd/wfsim/core.py#L877



Usage:
```
strax.Context(
        storage=strax.DataDirectory('./strax_data'),
        register=wfsim.RawRecordsFromFaxNT,
        config=dict(detector='XENONnT',
                   fax_config='https://raw.githubusercontent.com/XENONnT/'
                 'strax_auxiliary_files/master/fax_files/fax_config_nt.json',
                    **straxen.contexts.xnt_common_config,),
        **straxen.contexts.common_opts)
```

I've made a pull request here to add these contexts to straxen
https://github.com/XENONnT/straxen/pull/127

I'll also update the tutorials