### PR TITLE
Fix optical

### DIFF
--- a/wfsim/core.py
+++ b/wfsim/core.py
@@ -57,6 +57,11 @@ class Pulse(object):
 
         counts_start = 0 # Secondary loop index for assigning channel
         for channel, counts in zip(*np.unique(self._photon_channels, return_counts=True)):
+
+            #TODO: This is temporary continue to avoid out-of-range error.
+            # It should be added a proper method for nVeto PMTs also.
+            if channel >= 2000:
+                continue
             # Use 'counts' amount of photon for this channel 
             _channel_photon_timings = self._photon_timings[counts_start:counts_start+counts]
             counts_start += counts

--- a/wfsim/strax_interface.py
+++ b/wfsim/strax_interface.py
@@ -73,8 +73,8 @@ def read_optical(file):
 
     # Events should be in the TPC
     xp = e.array("xp_pri") / 10
-    yp = e.array("xp_pri") / 10
-    zp = e.array("xp_pri") / 10
+    yp = e.array("yp_pri") / 10
+    zp = e.array("zp_pri") / 10
 
     channels = e.array("pmthitID")
     timings = e.array("pmthitTime")*1e9

--- a/wfsim/strax_interface.py
+++ b/wfsim/strax_interface.py
@@ -65,7 +65,7 @@ def rand_instructions(c):
 def read_optical(file):
     data = uproot.open(file)
     all_ttrees = dict(data.allitems(filterclass=lambda cls: issubclass(cls, uproot.tree.TTreeMethods)))
-    e = all_ttrees[b'events/events;1']
+    e = all_ttrees[next(iter(all_ttrees))]
 
     n_events = len(e.array('eventid'))
     # lets separate the events in time by a constant time difference
@@ -109,7 +109,7 @@ def read_g4(c, file):
 
     data = uproot.open(file)
     all_ttrees = dict(data.allitems(filterclass=lambda cls: issubclass(cls, uproot.tree.TTreeMethods)))
-    e = all_ttrees[b'events/events;1']
+    e = all_ttrees[next(iter(all_ttrees))]
 
     time = e.array('time')
     n_events = len(e.array('time'))

--- a/wfsim/strax_interface.py
+++ b/wfsim/strax_interface.py
@@ -77,6 +77,10 @@ def read_optical(file):
     zp = e.array("zp_pri") / 10
 
     channels = e.array("pmthitID")
+    # TODO: It should be fixed following PMT mapping.
+    # In our MC, TPC PMT IDs are assigned at 10000-- -> 0--
+    # nVeto ones are assigned at 20000-- -> 2000--
+    channels = [[channel - 10000 if channel < 20000 else channel - 18000 for channel in array] for array in channels]
     timings = e.array("pmthitTime")*1e9
 
     ins = np.zeros(n_events, dtype=instruction_dtype)


### PR DESCRIPTION
I would like to add methods for nVeto pulses. It strongly depends on the Geant4 optical simulation.
To prepare this implementation and test, I fixed obvious errors on 'optical', and add workaround lines to be fixed for the future.