### PR TITLE
Sort _truth by time

### DIFF
--- a/wfsim/strax_interface.py
+++ b/wfsim/strax_interface.py
@@ -220,6 +220,7 @@ class ChunkRawRecords(object):
             _truth[name] = truth[name]
         _truth['time'][~np.isnan(_truth['t_first_photon'])] = \
             _truth['t_first_photon'][~np.isnan(_truth['t_first_photon'])].astype(int)
+        _truth.sort(order='time')
         if self.config['detector']=='XENON1T':
             yield dict(raw_records=records,
                        truth=_truth)


### PR DESCRIPTION
Hi WFSim experts! 
**What**
I noticed that the truth is not always sorted by time. I wondered if I should ask/file an issue but actually it looks like it's quite straight forward to solve (assuming I'm correct which I might not be). 

We could even delete the ` truth.sort(order='time')` call a few lines above. Let me know what you think.

Perhaps there is a good reason why the truth is not sorted by time, please consider this PR as an Issue/question in that case.

**Why?**
Reason for this PR is that I'm writing a matching `LoopPlugin` that needs sorted 'time' information. Of course this is trivial to make in case you guys think this is not to be handled as in this PR. Let me know what you think:
```python
class SortTruth(strax.Plugin):
    depends_on = 'truth'
    provides = 'truth_sorted'
    
    def infer_dtype(self):
        return strax.unpack_dtype(self.deps['truth'].dtype_for('truth'))
   
    def compute(self, truth):
        res = truth.copy()
        res.sort(order='time')
        return res
```` 