### PR TITLE
use files database

### DIFF
--- a/tests/test_wfsim.py
+++ b/tests/test_wfsim.py
@@ -12,15 +12,20 @@ run_id = '010000'
 def test_sim_1T():
     """Test the 1T simulator (should always work with the publicly available files)"""
     with tempfile.TemporaryDirectory() as tempdir:
+        testing_config_1T = dict(
+            hev_gain_model=('to_pe_constant', 0.0085),
+            gain_model=('to_pe_constant', 0.0085)
+        )
         st = strax.Context(
             storage=tempdir,
             config=dict(
                 nchunk=1, event_rate=1, chunk_size=10,
                 detector='XENON1T',
-                fax_config='https://raw.githubusercontent.com/XENONnT/strax_auxiliary_files/7ba4875b52162cbbe9284faf66a6b9193a254a30/sim_files/fax_config_1t.json',
+                fax_config='https://raw.githubusercontent.com/XENONnT/strax_auxiliary_files/7ba4875b52162cbbe9284faf66a6b9193a254a30/sim_files/fax_config_1t.json',  # noqa
                 **straxen.contexts.x1t_common_config),
             **straxen.contexts.common_opts)
         st.register(wfsim.RawRecordsFromFax1T)
+        st.set_config(testing_config_1T)
 
         rr = st.get_array(run_id, 'raw_records')
         p = st.get_array(run_id, 'peaks')
@@ -30,7 +35,8 @@ def test_sim_1T():
 def test_sim_nT():
     """Test the nT simulator. Works only if one has access to the XENONnT databases"""
     if straxen.uconfig is None:
-        # This means we cannot load the nT files. Most likely will work locally but not a travis job.
+        # This means we cannot load the nT files. Most likely will work
+        # locally but not a travis job.
         return
     with tempfile.TemporaryDirectory() as tempdir:
         st = strax.Context(

--- a/tests/test_wfsim.py
+++ b/tests/test_wfsim.py
@@ -15,13 +15,11 @@ def test_sim():
             config=dict(
                 nchunk=1, event_rate=1, chunk_size=10,
                 detector='XENONnT',
-                fax_config='https://raw.githubusercontent.com/XENONnT/'
-                           'strax_auxiliary_files/master/fax_files/fax_config_nt.json',
+                fax_config='https://raw.githubusercontent.com/XENONnT/strax_auxiliary_files/90a532347fe46fe84fc3ad4f89241c9b0928bd43/fax_files/fax_config_nt.json',
                 **straxen.contexts.xnt_common_config),
             **straxen.contexts.common_opts)
         st.register(wfsim.RawRecordsFromFaxNT)
-        st.config['gain_model'] = ('to_pe_per_run', 'https://raw.githubusercontent.com/XENONnT/'
-            'strax_auxiliary_files/master/fax_files/to_pe_nt.npy')
+        st.config['gain_model'] = ('to_pe_constant', 0.0085)
 
         rr = st.get_array(run_id, 'raw_records')
         p = st.get_array(run_id, 'peaks')

--- a/tests/test_wfsim.py
+++ b/tests/test_wfsim.py
@@ -8,18 +8,40 @@ strax.mailbox.Mailbox.DEFAULT_TIMEOUT = 60
 
 run_id = '010000'
 
-def test_sim():
+
+def test_sim_1T():
+    """Test the 1T simulator (should always work with the publicly available files)"""
     with tempfile.TemporaryDirectory() as tempdir:
         st = strax.Context(
             storage=tempdir,
             config=dict(
                 nchunk=1, event_rate=1, chunk_size=10,
                 detector='XENON1T',
-                fax_config='https://raw.githubusercontent.com/XENONnT/strax_auxiliary_files/90a532347fe46fe84fc3ad4f89241c9b0928bd43/fax_files/fax_config_1t.json',
+                fax_config='https://raw.githubusercontent.com/XENONnT/strax_auxiliary_files/7ba4875b52162cbbe9284faf66a6b9193a254a30/sim_files/fax_config_1t.json',
                 **straxen.contexts.x1t_common_config),
             **straxen.contexts.common_opts)
         st.register(wfsim.RawRecordsFromFax1T)
-        st.config['gain_model'] = ('to_pe_constant', 0.0085)
+
+        rr = st.get_array(run_id, 'raw_records')
+        p = st.get_array(run_id, 'peaks')
+        _sanity_check(rr, p)
+
+
+def test_sim_nT():
+    """Test the nT simulator. Works only if one has access to the XENONnT databases"""
+    if straxen.uconfig is None:
+        # This means we cannot load the nT files. Most likely will work locally but not a travis job.
+        return
+    with tempfile.TemporaryDirectory() as tempdir:
+        st = strax.Context(
+            storage=tempdir,
+            config=dict(
+                nchunk=1, event_rate=1, chunk_size=10,
+                detector='XENONnT',
+                fax_config='fax_config_nt.json',
+                **straxen.contexts.xnt_common_config),
+            **straxen.contexts.common_opts)
+        st.register(wfsim.RawRecordsFromFaxNT)
 
         rr = st.get_array(run_id, 'raw_records')
         p = st.get_array(run_id, 'peaks')

--- a/tests/test_wfsim.py
+++ b/tests/test_wfsim.py
@@ -14,11 +14,11 @@ def test_sim():
             storage=tempdir,
             config=dict(
                 nchunk=1, event_rate=1, chunk_size=10,
-                detector='XENONnT',
-                fax_config='https://raw.githubusercontent.com/XENONnT/strax_auxiliary_files/90a532347fe46fe84fc3ad4f89241c9b0928bd43/fax_files/fax_config_nt.json',
-                **straxen.contexts.xnt_common_config),
+                detector='XENON1T',
+                fax_config='https://raw.githubusercontent.com/XENONnT/strax_auxiliary_files/90a532347fe46fe84fc3ad4f89241c9b0928bd43/fax_files/fax_config_1t.json',
+                **straxen.contexts.x1t_common_config),
             **straxen.contexts.common_opts)
-        st.register(wfsim.RawRecordsFromFaxNT)
+        st.register(wfsim.RawRecordsFromFax1T)
         st.config['gain_model'] = ('to_pe_constant', 0.0085)
 
         rr = st.get_array(run_id, 'raw_records')

--- a/wfsim/core.py
+++ b/wfsim/core.py
@@ -280,11 +280,13 @@ class S1(Pulse):
 
         _, _, t, x, y, z, n_photons, recoil_type, *rest = [
             np.array(v).reshape(-1) for v in zip(*instruction)]
-        
+
         positions = np.array([x, y, z]).T  # For map interpolation
-        ly = np.squeeze(self.resource.s1_light_yield_map(positions),
-                       axis=-1)
-        if self.config['detector']=='XENON1T':
+        if self.config['detector']=='XENONnT':
+            ly = np.squeeze(self.resource.s1_light_yield_map(positions),
+                            axis=-1)
+        elif self.config['detector']=='XENON1T':
+            ly = self.resource.s1_light_yield_map(positions)
             ly *= self.config['s1_detection_efficiency']
         n_photons = np.random.binomial(n=n_photons, p=ly)
 
@@ -388,8 +390,12 @@ class S2(Pulse):
         else:
             z_obs, positions = z, np.array([x, y]).T
 
-        sc_gain = np.squeeze(self.resource.s2_light_yield_map(positions), axis=-1) \
-            * self.config['s2_secondary_sc_gain']
+        if self.config['detector']=='XENONnT':
+            sc_gain = np.squeeze(self.resource.s2_light_yield_map(positions), axis=-1) \
+                * self.config['s2_secondary_sc_gain']
+        elif self.config['detector']=='XENON1T':
+            sc_gain = self.resource.s2_light_yield_map(positions) \
+                * self.config['s2_secondary_sc_gain']
 
         # Average drift time of the electrons
         self.drift_time_mean = - z_obs / \

--- a/wfsim/core.py
+++ b/wfsim/core.py
@@ -497,6 +497,7 @@ class S2(Pulse):
             electron_trapping_time):
         assert len(timings) == np.sum(n_electron)
         assert len(gains) == np.sum(n_electron)
+        assert len(sc_gain) == len(t)
 
         i_electron = 0
         for i in np.arange(len(t)):
@@ -508,7 +509,7 @@ class S2(Pulse):
             drift_time_stdev /= drift_velocity_liquid
             # Calculate electron arrival times in the ELR region
 
-            for j in np.arange(n_electron[i]):
+            for _ in np.arange(n_electron[i]):
                 _timing = t[i] + \
                     np.random.exponential(electron_trapping_time)
                 _timing += np.random.normal(drift_time_mean, drift_time_stdev)

--- a/wfsim/load_resource.py
+++ b/wfsim/load_resource.py
@@ -58,6 +58,7 @@ class Resource:
             files[k] = config[k] # Allowing user to replace default with specified files
         commit = 'master'   # Replace this by a commit hash if you feel solid and responsible
         url_base = f'https://raw.githubusercontent.com/XENONnT/strax_auxiliary_files/{commit}/sim_files'
+        downloader = straxen.MongoDownloader()
         for k, v in files.items():
             if v.startswith('/'):
                 print(f"WARNING: Using local file {v} for a resource. "
@@ -65,9 +66,9 @@ class Resource:
             try:
                 # First try downloading it via
                 # https://straxen.readthedocs.io/en/latest/config_storage.html#downloading-xenonnt-files-from-the-database  # noqa
-                downloaded_file = straxen.get_resource(v)
+                downloaded_file = downloader.download_single(v)
                 files[k] = downloaded_file
-            except FileNotFoundError:
+            except (FileNotFoundError, ValueError):
                 # We cannot download the file from the database. We need to
                 # try to get a placeholder file from a URL.
                 files[k] = osp.join(url_base, v)

--- a/wfsim/load_resource.py
+++ b/wfsim/load_resource.py
@@ -58,7 +58,6 @@ class Resource:
             files[k] = config[k] # Allowing user to replace default with specified files
         commit = 'master'   # Replace this by a commit hash if you feel solid and responsible
         url_base = f'https://raw.githubusercontent.com/XENONnT/strax_auxiliary_files/{commit}/sim_files'
-        downloader = straxen.MongoDownloader()
         for k, v in files.items():
             if v.startswith('/'):
                 print(f"WARNING: Using local file {v} for a resource. "
@@ -66,9 +65,16 @@ class Resource:
             try:
                 # First try downloading it via
                 # https://straxen.readthedocs.io/en/latest/config_storage.html#downloading-xenonnt-files-from-the-database  # noqa
+
+                # we need to add the straxen.MongoDownloader() in this
+                # try: except NameError: logic because the NameError
+                # gets raised if we don't have access to utilix.
+                downloader = straxen.MongoDownloader()
+                # FileNotFoundError, ValueErrors can be raised if we
+                # cannot load the requested config
                 downloaded_file = downloader.download_single(v)
                 files[k] = downloaded_file
-            except (FileNotFoundError, ValueError):
+            except (FileNotFoundError, ValueError, NameError):
                 # We cannot download the file from the database. We need to
                 # try to get a placeholder file from a URL.
                 files[k] = osp.join(url_base, v)

--- a/wfsim/strax_interface.py
+++ b/wfsim/strax_interface.py
@@ -318,11 +318,9 @@ class ChunkRawRecordsOptical(ChunkRawRecords):
                  help="Terminate processing if any one mailbox receives "
                       "no result for more than this many seconds"),
     strax.Option('fax_config',
-                 default='https://raw.githubusercontent.com/XENONnT/'
-                 'strax_auxiliary_files/master/fax_files/fax_config_nt.json'),
+                 default='fax_config_nt.json'),
     strax.Option('gain_model',
-                 default=('to_pe_per_run', 'https://raw.githubusercontent.com/XENONnT/'
-                 'strax_auxiliary_files/master/fax_files/to_pe_nt.npy'),
+                 default=('to_pe_per_run', 'to_pe_nt.npy'),
                  help='PMT gain model. Specify as (model_type, model_config)'),
     strax.Option('detector', default='XENONnT', track=True),)
 class FaxSimulatorPlugin(strax.Plugin):


### PR DESCRIPTION
Use https://straxen.readthedocs.io/en/latest/config_storage.html#downloading-xenonnt-files-from-the-database to get nT files.

For nT, we can now use (if we are on the latest straxen master) the database to get the required files. All the files from https://github.com/XENONnT/strax_auxiliary_files and https://github.com/XENONnT/private_nt_aux_files are uploaded to the database. We should be able to download those files like this. 

Some testing from the WFSim experts would be appreciated because they are most likely much better in isolating potential issues than I am.
