### PR TITLE
Fix missing configs

### DIFF
--- a/wfsim/core.py
+++ b/wfsim/core.py
@@ -298,7 +298,7 @@ class S1(Pulse):
         super().__call__()
 
     def photon_channels(self, points, n_photons):
-        channels = np.array(self.config['channels_in_detector']['tpc'])
+        channels = np.arange(len(self.config['gains']))
         p_per_channel = self.resource.s1_pattern_map(points)
         p_per_channel[:, np.in1d(channels, self.turned_off_pmts)] = 0
         


### PR DESCRIPTION
In https://github.com/XENONnT/private_nt_aux_files/pull/3/commits/35a1a79a009cf7d4c571dbb7eb95876eef423d82 some configs were deleted that were needed in WFSim, we can set them as defaults for nT.

I leave it to the developers to decide if they want to reinstate those entries in the `fax_config_nt.json` or just upload a channel map to the config or so with start and stops.