### PR TITLE
Return correct PMT ID for nVeto

### DIFF
--- a/wfsim/strax_interface.py
+++ b/wfsim/strax_interface.py
@@ -370,6 +370,7 @@ class FaxSimulatorPlugin(strax.Plugin):
         """Return whether all instructions has been used."""
         return self.sim.source_finished()
 
+
 @export
 class RawRecordsFromFaxNT(FaxSimulatorPlugin):
     provides = ('raw_records', 'raw_records_he', 'raw_records_aqmon', 'truth')
@@ -421,6 +422,7 @@ class RawRecordsFromFaxNT(FaxSimulatorPlugin):
             data=result[data_type],
             data_type=data_type) for data_type in self.provides}
 
+
 @export
 class RawRecordsFromFaxEpix(RawRecordsFromFaxNT):
     depends_on = 'epix_instructions'
@@ -470,15 +472,15 @@ class RawRecordsFromFaxOptical(RawRecordsFromFaxNT):
 class RawRecordsFromFaxnVeto(RawRecordsFromFaxOptical):
     provides = ('raw_records_nv', 'truth')
     data_kind = immutabledict(zip(provides, provides))
-    #Why does the data_kind need to be repeated?? So the overriding of the 
+    # Why does the data_kind need to be repeated?? So the overriding of the 
     # provides doesn't work in the setting of the data__kind?
 
     def compute(self):
         result = super().compute()
-        result['raw_records_nv'].data['channel'] += 2000#nVeto PMT ID offset
+        result['raw_records_nv'].data['channel'] += 2000  # nVeto PMT ID offset
         return result
 
 
     def check_instructions(self):
-        #Are there some nveto boundries we need to include?
+        # Are there some nveto boundries we need to include?
         pass

--- a/wfsim/strax_interface.py
+++ b/wfsim/strax_interface.py
@@ -473,6 +473,11 @@ class RawRecordsFromFaxnVeto(RawRecordsFromFaxOptical):
     #Why does the data_kind need to be repeated?? So the overriding of the 
     # provides doesn't work in the setting of the data__kind?
 
+    def compute(self):
+        result = super().compute()
+        result['raw_records_nv'].data['channel'] += 2000#nVeto PMT ID offset
+        return result
+
 
     def check_instructions(self):
         #Are there some nveto boundries we need to include?


### PR DESCRIPTION
WFSim uses PMT ID started on 0 for also nVeto option.
However, it is convenient to return the correct ID (2000--2119) is useful for analyst.
I've checked it works, please review the lines.