### PR TITLE
Geant4 event ID in truth

### DIFF
--- a/wfsim/strax_interface.py
+++ b/wfsim/strax_interface.py
@@ -92,7 +92,7 @@ def read_optical(c):
     ins['z'] = e["zp_pri"].array(library="np").flatten() / 10.
     ins['time']= 1e7 * time.flatten()
     ins['event_number'] = np.arange(n_events)
-    ins['g4id'] = np.arange(event_id)
+    ins['g4id'] = event_id
     ins['type'] = np.repeat(1, n_events)
     ins['recoil'] = np.repeat(1, n_events)
     ins['amp'] = [len(t) for t in timings]

--- a/wfsim/strax_interface.py
+++ b/wfsim/strax_interface.py
@@ -71,7 +71,8 @@ def read_optical(c):
     except:
         raise Exception("Are you using mc version >4?")
 
-    n_events = len(e['eventid'].array(library="np"))
+    event_id = e['eventid'].array(library="np")
+    n_events = len(event_id)
     # lets separate the events in time by a constant time difference
     time = np.arange(1, n_events+1)
 
@@ -91,6 +92,7 @@ def read_optical(c):
     ins['z'] = e["zp_pri"].array(library="np").flatten() / 10.
     ins['time']= 1e7 * time.flatten()
     ins['event_number'] = np.arange(n_events)
+    ins['g4id'] = np.arange(event_id)
     ins['type'] = np.repeat(1, n_events)
     ins['recoil'] = np.repeat(1, n_events)
     ins['amp'] = [len(t) for t in timings]


### PR DESCRIPTION
I added 'g4id' in truth using optical simulation. (In the current implementation, they are empty.)
It works.

In the far team-D telecon, I said unique event ID is enough to match TPC and nVeto events, but it is not correct.
Multi 'raw_records' and 'raw_records_nv' are created in one Geant4 event. In other words, more raw records are generated for one truth. We cannot match that because we don't know which truth created one specific raw record.
(Using event time, we can guess that but I think it is not straight-forward solution.)
Am I missing important thing? Please give me a comment and let's start a discussion.