### PR TITLE
add h-diffusion function

### DIFF
--- a/wfsim/core.py
+++ b/wfsim/core.py
@@ -619,12 +619,12 @@ class S2(Pulse):
     def s2_pattern_map_hdiff(self, n_electron, z, xy):
         drift_time_gate = self.config['drift_time_gate']
         drift_velocity_liquid = self.config['drift_velocity_liquid']
-        diffusion_constant_liquid_horizontal = getattr(self.config, 'diffusion_constant_liquid_horizontal', 0)
+        diffusion_constant_transverse = getattr(self.config, 'diffusion_constant_transverse', 0)
 
         assert all(z < 0), 'All S2 in liquid should have z < 0'
 
         drift_time_mean = - z / drift_velocity_liquid + drift_time_gate  # Add gate time for consistancy?
-        hdiff_stdev = np.sqrt(2 * diffusion_constant_liquid_horizontal * drift_time_mean)
+        hdiff_stdev = np.sqrt(2 * diffusion_constant_transverse * drift_time_mean)
 
         hdiff = np.random.normal(0, 1, (np.sum(n_electron), 2)) * np.repeat(hdiff_stdev, n_electron, axis=0).reshape((-1, 1))
         # Should we also output this xy position in truth?
@@ -655,7 +655,7 @@ class S2(Pulse):
         top_index = np.arange(self.config['n_top_pmts'])
         bottom_index = np.array(self.config['channels_bottom'])
 
-        if getattr(self.config, 'diffusion_constant_liquid_horizontal', 0) > 0:
+        if getattr(self.config, 'diffusion_constant_transverse', 0) > 0:
             pattern = self.s2_pattern_map_hdiff(n_electron, z_obs, positions)  # [position, pmt]
         else:
             pattern = self.resource.s2_pattern_map(positions)  # [position, pmt]

--- a/wfsim/core.py
+++ b/wfsim/core.py
@@ -653,7 +653,12 @@ class S2(Pulse):
         return pattern
 
     def photon_channels(self, n_electron, z_obs, positions):
-        # TODO log this
+        """Set the _photon_channels property list of length same as _photon_timings
+
+        :param n_electron: a 1d int array
+        :param z_obs: a 1d float array
+        :param positions: a 2d float array of shape [n interaction, 2] for the xy coordinate
+        """
         if len(self._photon_timings) == 0:
             self._photon_channels = []
             return 1


### PR DESCRIPTION
We have been ignoring horizontal diffusion so far, which might impact the S2 pattern.

The added function in S2 pattern generation would now output diffused patterns, but with naive calculations

  - One can set an additional parameter `diffusion_constant_liquid_horizontal` in config to enable this
  - We will create updated xy positions for all electrons in each S2, the new pattern is calculated averaging over those new positions.
    - Positions outside the TPC radius will be ignored, as the output will be the average over all other positions.
    - It's not a weighted average, as an electron with 50 photon carries the same weight as an electron with 20 photon
    - There's no enforced time-positon correlation at this per electron level.