### PR TITLE
Back to old detector naming

### DIFF
--- a/wfsim/core.py
+++ b/wfsim/core.py
@@ -291,7 +291,7 @@ class S1(Pulse):
             np.array(v).reshape(-1) for v in zip(*instruction)]
 
         positions = np.array([x, y, z]).T  # For map interpolation
-        if self.config['detector']=='xenonnt_detector':
+        if self.config['detector']=='XENONnT':
             ly = np.squeeze(self.resource.s1_light_yield_map(positions),
                             axis=-1)
         elif self.config['detector']=='XENON1T':
@@ -403,7 +403,7 @@ class S2(Pulse):
         else:
             z_obs, positions = z, np.array([x, y]).T
 
-        if self.config['detector']=='xenonnt_detector':
+        if self.config['detector']=='XENONnT':
             sc_gain = np.squeeze(self.resource.s2_light_yield_map(positions), axis=-1) \
                 * self.config['s2_secondary_sc_gain']
         elif self.config['detector']=='XENON1T':
@@ -1025,7 +1025,7 @@ class RawData(object):
                 
                 self._raw_data[ch, _slice] += adc_wave
 
-                if self.config['detector'] == 'xenonnt_detector':
+                if self.config['detector'] == 'XENONnT':
                     adc_wave_he = adc_wave * int(self.config['high_energy_deamplification_factor'])
                     if ch < self.config['n_top_pmts']:
                         ch_he = np.arange(self.config['channel_map']['he'][0],self.config['channel_map']['he'][1]+1)[ch]

--- a/wfsim/load_resource.py
+++ b/wfsim/load_resource.py
@@ -32,7 +32,7 @@ class Resource:
             'ele_ap_cdfs': 'ele_after_pulse.npy',
             'noise_file': 'x1t_noise_170203_0850_00_small.npz',
         }
-        if config['detector'] == 'xenon1t_detector':
+        if config['detector'] == 'XENON1T':
             files.update({
                 'photon_area_distribution': 'XENON1T_spe_distributions.csv',
                 's1_light_yield_map': 'XENON1T_s1_xyz_ly_kr83m_SR1_pax-680_fdc-3d_v0.json',
@@ -42,7 +42,7 @@ class Resource:
                 'photon_ap_cdfs': 'x1t_pmt_afterpulse_config.pkl.gz',
                 'fdc_3d': 'XENON1T_FDC_SR1_data_driven_time_dependent_3d_correction_tf_nn_part1_v1.json.gz',
             })
-        elif config['detector'] == 'xenonnt_detector':
+        elif config['detector'] == 'XENONnT':
             files.update({
                 'photon_area_distribution': 'XENONnT_spe_distributions.csv',
                 's1_pattern_map': 'XENONnT_s1_xyz_patterns_corrected_MCv3.1.0_disks.pkl',
@@ -81,14 +81,14 @@ class Resource:
 
         self.photon_area_distribution = straxen.get_resource(files['photon_area_distribution'], fmt='csv')
 
-        if config['detector'] == 'xenon1t_detector':
+        if config['detector'] == 'XENON1T':
             self.s1_pattern_map = make_map(files['s1_pattern_map'], fmt='json.gz')
             self.s1_light_yield_map = make_map(files['s1_light_yield_map'], fmt='json')
             self.s2_light_yield_map = make_map(files['s2_light_yield_map'], fmt='json')
             self.s2_pattern_map = make_map(files['s2_pattern_map'], fmt='json.gz')
             self.fdc_3d = make_map(files['fdc_3d'], fmt='json.gz')
 
-        if config['detector'] == 'xenonnt_detector':
+        if config['detector'] == 'XENONnT':
             self.s1_pattern_map = make_map(files['s1_pattern_map'], fmt='pkl')
             lymap = deepcopy(self.s1_pattern_map)
             lymap.data['map'] = np.sum(lymap.data['map'][:][:][:], axis=3, keepdims=True)

--- a/wfsim/strax_interface.py
+++ b/wfsim/strax_interface.py
@@ -224,13 +224,13 @@ class ChunkRawRecords(object):
         _truth.sort(order='time')
 
         #Oke this will be a bit ugly but it's easy
-        if self.config['detector']=='xenon1t_detector':
+        if self.config['detector']=='XENON1T':
             yield dict(raw_records=records,
                        truth=_truth)
         if self.config['neutron_veto']:
             yield dict(raw_records_nv=records[records['channel'] < self.config['channel_map']['he'][0]],
                        truth=_truth)
-        elif self.config['detector']=='xenonnt_detector':
+        elif self.config['detector']=='XENONnT':
             yield dict(raw_records=records[records['channel'] < self.config['channel_map']['he'][0]],
                        raw_records_he=records[(records['channel'] >= self.config['channel_map']['he'][0]) &
                                               (records['channel'] <= self.config['channel_map']['he'][-1])],
@@ -279,7 +279,7 @@ class ChunkRawRecordsOptical(ChunkRawRecords):
     strax.Option('gain_model',
                  default=('to_pe_per_run', 'https://github.com/XENONnT/private_nt_aux_files/blob/master/sim_files/to_pe_nt.npy?raw=true'),
                  help='PMT gain model. Specify as (model_type, model_config).'),
-    strax.Option('detector', default='xenonnt_detector', track=True),
+    strax.Option('detector', default='XENONnT', track=True),
     strax.Option('channel_map', track=False, type=immutabledict,
                  help="immutabledict mapping subdetector to (min, max) "
                       "channel number. Provided by context"),


### PR DESCRIPTION
To keep consistency with MC and epix. Sorry @petergaemers for the confusion.

This also solves a failure when trying to run 1T sims, since the renaming to `xenonXt_detector` hadn't been propagated in this case.