### PR TITLE
Update nT pattern maps

### DIFF
--- a/wfsim/load_resource.py
+++ b/wfsim/load_resource.py
@@ -45,8 +45,8 @@ class Resource:
         elif config['detector'] == 'XENONnT':
             files.update({
                 'photon_area_distribution': 'XENONnT_spe_distributions.csv',
-                's1_pattern_map': 'XENONnT_s1_xyz_patterns_corrected_MCv3.1.0_disks.pkl',
-                's2_pattern_map': 'XENONnT_s2_xy_patterns_topbottom_corrected_MCv3.1.0_disks.pkl',
+                's1_pattern_map': 'XENONnT_s1_xyz_patterns_corrected_qes_MCva43fa9b_wires.pkl',
+                's2_pattern_map': 'XENONnT_s2_xy_patterns_topbottom_corrected_qes_MCva43fa9b_wires.pkl',
                 'photon_ap_cdfs': 'xnt_pmt_afterpulse_config.pkl.gz',
                 's2_luminescence': 'XENONnT_s2_garfield_luminescence_distribution_v0.pkl.gz',
                 'gas_gap_map': 'gas_gap_warping_map_January_2021.pkl',


### PR DESCRIPTION
This PR is following https://github.com/XENONnT/private_nt_aux_files/pull/23.

---

**What has changed?**

For `XENONnT_s1_xyz_patterns_corrected_qes_MCva43fa9b_wires.pkl`:

- actual electrode wires are used within Geant4 instead of thin disks
- QEs of the PMTs as reported by Hamamatsu were added. We assume that these QEs already include the DPE judging by the way the QEs are measured. Therefore, we should divide by the corresponding DPE value like: `map/(1 + DPE)`
- One can express the saved value as: `APE = LCE(x,y,z)*corrections*QE` (see [this note](https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenonnt:althueser:20201014_optical_simulation_s1_absl))

For `XENONnT_s2_xy_patterns_topbottom_corrected_qes_MCva43fa9b_wires.pkl`

- actual electrode wires are used within Geant4 instead of thin disks
- QEs of the PMTs as reported by Hamamatsu were added. We assume that these QEs already include the DPE judging by the way the QEs are measured.
- This map is not a LCE or APE map. It can only be used after normalization to distribute S2 patterns.

**What should we change in WFSim?**

- We should make sure that we are calculating the S1 ly as it should, see above.
- We cannot use the current S2 map for S2 ly calculation - but if we decide that we want to do that, we (Andrii and me) can provide a S2 LCE or APE map so that we can get the ly from it.