### PR TITLE
Correct detector naming

### DIFF
--- a/wfsim/core.py
+++ b/wfsim/core.py
@@ -308,7 +308,7 @@ class S1(Pulse):
 
     @staticmethod
     def get_n_photons(n_photons,positions, s1_light_yield_map, config):
-        if config['detector']=='xenonnt_detector':
+        if config['detector']=='XENONnT':
             ly = np.squeeze(s1_light_yield_map(positions),
                             axis=-1)/(1+self.config['p_double_pe_emision'])
         elif config['detector']=='XENON1T':


### PR DESCRIPTION
Our old `"xenonnt_detector"` was reintroduced in here: https://github.com/XENONnT/WFSim/pull/83
@jorana @petergaemers Shouldn't the test have triggered something in this case, since `ly` isn't called?

I will push a new tag after this is merge, if you agree.