### PR TITLE
Add github actions to repo

### DIFF
--- a/.github/workflows/Pipi.yml
+++ b/.github/workflows/Pipi.yml
@@ -1,0 +1,30 @@
+# Lets upload wfsim to PyPi to make it pip instalable
+# Mostly based on https://github.com/marketplace/actions/pypi-publish
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      # Setup steps
+      - name: Setup python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.6'
+      - name: Checkout repo
+        uses: actions/checkout@v2
+      - name: Install dependencies
+        run: pip install wheel
+      - name: Build package
+        run: python setup.py sdist bdist_wheel
+      # Do the publish
+      - name: Publish a Python distribution to PyPI
+        # Might want to add but does not work on workflow_dispatch :
+        # if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user:  __token__
+          password: ${{ secrets.pypi_password }}

--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -29,7 +29,8 @@ jobs:
       uses: py-actions/py-dependency-install@v2
     - name: Install requirements
       run: |
-          python setup.py install
+        pip install pytest hypothesis flake8 pytest-cov coveralls pytest
+        python setup.py install
     - name: Coveralls
       env:
         COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_TOKEN }}

--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -1,0 +1,39 @@
+on:
+  workflow_dispatch:
+  release:
+    types: [created]
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+
+name: Test Coveralls
+
+jobs:
+
+  build:
+    name: Coveralls
+    runs-on: ubuntu-latest
+    steps:
+
+    - uses: actions/checkout@v1
+    - name: Setup python
+      uses: actions/setup-python@v2 # https://github.com/marketplace/actions/setup-miniconda
+      with:
+        python-version: 3.8
+    - name: Checkout repo
+      uses: actions/checkout@v2
+    - name: Install python dependencies
+      uses: py-actions/py-dependency-install@v2
+    - name: Install requirements
+      run: |
+          python setup.py install
+    - name: Coveralls
+      env:
+        COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_TOKEN }}
+        NUMBA_DISABLE_JIT: 1
+      run: |
+        coverage run --source=wfsim setup.py test
+        coveralls

--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -35,8 +35,8 @@ jobs:
         uses: py-actions/py-dependency-install@v2
       - name: Install dependencies
         run: |
-          pip install pytest hypothesis flake8 pytest-cov
-          python setup.py intall
+          pip install pytest flake8 pytest-cov pytest hypothesis
+          python setup.py install
       - name: Do the test
         if: matrix.os == 'windows-latest'
         run: |

--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -1,0 +1,45 @@
+# Test package every time
+
+name: Pytest
+
+# Controls when the action will run.
+
+# Trigger this code when a new release is published
+on:
+  workflow_dispatch:
+  release:
+    types: [created]
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+
+jobs:
+  update:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-latest"]
+        python-version: ["3.8"]
+    steps:
+      - name: Setup python
+        uses: actions/setup-python@v2 # https://github.com/marketplace/actions/setup-miniconda
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Checkout repo
+        uses: actions/checkout@v2
+      - name: Install python dependencies
+        uses: py-actions/py-dependency-install@v2
+      - name: Install dependencies
+        run: |
+          pip install pytest hypothesis flake8 pytest-cov
+          python setup.py intall
+      - name: Do the test
+        if: matrix.os == 'windows-latest'
+        run: |
+            pytest
+      - name: goodbye
+        run: echo goodbye

--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -17,7 +17,7 @@ on:
       - master
 
 jobs:
-  update:
+  test wfsim:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -17,7 +17,7 @@ on:
       - master
 
 jobs:
-  test wfsim:
+  test_wfsim:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -38,7 +38,7 @@ jobs:
           pip install pytest flake8 pytest-cov pytest hypothesis
           python setup.py install
       - name: Do the test
-        if: matrix.os == 'windows-latest'
+        if: matrix.os == 'ubuntu-latest'
         run: |
             pytest
       - name: goodbye

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Build Status](https://travis-ci.org/XENONnT/WFSim.svg?branch=master)](https://travis-ci.org/XENONnT/WFSim)
 [![Coverage Status](https://coveralls.io/repos/github/XENONnT/WFSim/badge.svg?branch=ci_testing)](https://coveralls.io/github/XENONnT/WFSim?branch=ci_testing)
 [![Pytest](https://github.com/XENONnT/WFSim/workflows/Pytest/badge.svg?branch=master)](https://github.com/XENONnT/WFSim/actions?query=workflow%3APytest)
+[![CodeFactor](https://www.codefactor.io/repository/github/xenonnt/wfsim/badge)](https://www.codefactor.io/repository/github/xenonnt/wfsim)
 
 Here are the files needed to run the waveform simulator fax and give output in the same formats as used by strax.
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Coverage Status](https://coveralls.io/repos/github/XENONnT/WFSim/badge.svg?branch=ci_testing)](https://coveralls.io/github/XENONnT/WFSim?branch=ci_testing)
 [![Pytest](https://github.com/XENONnT/WFSim/workflows/Pytest/badge.svg?branch=master)](https://github.com/XENONnT/WFSim/actions?query=workflow%3APytest)
 [![CodeFactor](https://www.codefactor.io/repository/github/xenonnt/wfsim/badge)](https://www.codefactor.io/repository/github/xenonnt/wfsim)
+[![PyPI version shields.io](https://img.shields.io/pypi/v/wfsim.svg)](https://pypi.python.org/pypi/wfsim/)
 
 Here are the files needed to run the waveform simulator fax and give output in the same formats as used by strax.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Fax in strax
 
 [![Build Status](https://travis-ci.org/XENONnT/WFSim.svg?branch=master)](https://travis-ci.org/XENONnT/WFSim)
+[![Coverage Status](https://coveralls.io/repos/github/XENONnT/WFSim/badge.svg?branch=ci_testing)](https://coveralls.io/github/XENONnT/WFSim?branch=ci_testing)
+[![Pytest](https://github.com/XENONnT/WFSim/workflows/Pytest/badge.svg?branch=master)](https://github.com/XENONnT/WFSim/actions?query=workflow%3APytest)
 
 Here are the files needed to run the waveform simulator fax and give output in the same formats as used by strax.
 

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -2,4 +2,4 @@
 
 **WFSim needs you:**
  - Please add a test for this PR, as a bare minimum, make sure it's covered in coveralls!
- - Can you add a docsting to all your functions!
+ - Can you add a docsting to all your functions?

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -1,0 +1,5 @@
+**What is the problem / what does the code in this PR do**
+
+**WFSim needs you:**
+ - Please add a test for this PR, as a bare minimum, make sure it's covered in coveralls!
+ - Can you add a docsting to all your functions!

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -37,4 +37,3 @@ def test_noise(data_length, n_channels, noise_data_length):
 
     # Actually test that we can run the function
     noise_function(data, channel_mask, noise_data, noise_data_length)
-

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -34,6 +34,7 @@ def test_noise(data_length, n_channels, noise_data_length):
 
     RawData = wfsim.RawData
     noise_function = RawData.add_noise
-    
+
     # Actually test that we can run the function
     noise_function(data, channel_mask, noise_data, noise_data_length)
+

--- a/wfsim/core.py
+++ b/wfsim/core.py
@@ -236,8 +236,9 @@ class Pulse(object):
             if photon_timings[i] > tmp_photon_timing:
                 start = int(tmp_photon_timing // dt) - pulse_left
                 reminder = int(tmp_photon_timing % dt)
+                HACK_OFF_BY_ONE_ERROR = len(pulse_current[start:start + template_length])
                 pulse_current[start:start + template_length] += \
-                    pmt_current_templates[reminder] * gain_total
+                    pmt_current_templates[reminder][:HACK_OFF_BY_ONE_ERROR] * gain_total
 
                 gain_total = photon_gains[i]
                 tmp_photon_timing = photon_timings[i]
@@ -246,8 +247,9 @@ class Pulse(object):
         else:
             start = int(tmp_photon_timing // dt) - pulse_left
             reminder = int(tmp_photon_timing % dt)
+            HACK_OFF_BY_ONE_ERROR = len(pulse_current[start:start + template_length])
             pulse_current[start:start + template_length] += \
-                pmt_current_templates[reminder] * gain_total
+                pmt_current_templates[reminder][:HACK_OFF_BY_ONE_ERROR] * gain_total
 
     @staticmethod
     def singlet_triplet_delays(size, singlet_ratio, config, phase):


### PR DESCRIPTION
In this PR:
- I added github actions to do the CI testing, github actions are much faster than travis, allowing effective testing instead of everlasting waits and eventual ignoring the tests all together
- It also add a github actions service for doing the coveralls uploads, this also tests the repo but simultaneously checks how many lines are covered by the tests
- To remind everyone of tests, etc, I've added a template to remind the author if he/she can add doc-strings and tests, however tedious it may be,
- It's now pip installable!
- The readme has been updated with the badges corresponding to these tests:
![afbeelding](https://user-images.githubusercontent.com/22295914/108239924-a5e99780-714a-11eb-96de-57f6b8a1c23e.png)
