### PR TITLE
Bug fix for endtime of truth

### DIFF
--- a/wfsim/core.py
+++ b/wfsim/core.py
@@ -1215,6 +1215,8 @@ class RawData(object):
                 tb[field] = np.mean(value)
             elif len(instruction) > 1 and field == 'amp':
                 tb[field] = np.sum(value)
+            elif field == 'endtime':
+                pass
             else:
                 # Cannot summarize intelligently: just take the first value
                 tb[field] = value[0]


### PR DESCRIPTION
At here
https://github.com/XENONnT/WFSim/blob/3fbae1f9478401fe318b51b27b2b78df0324b833/wfsim/core.py#L1220

endtime of truth has been overwritten to the initial instruction value (0) for all time.
Thus, we always got 0 in truth. 

I would like to check for other parameters not to do like that. (I just checked `endtime`.)
