### PR TITLE
New default nT config file

### DIFF
--- a/notebooks/Understanding_WFSim_P1.ipynb
+++ b/notebooks/Understanding_WFSim_P1.ipynb
@@ -27,7 +27,7 @@
    "outputs": [],
    "source": [
     "config = straxen.get_resource('https://raw.githubusercontent.com/XENONnT/'\n",
-    "                 'strax_auxiliary_files/master/fax_files/fax_config_nt.json', fmt='json')\n",
+    "                 'strax_auxiliary_files/master/fax_files/fax_config_nt_design.json', fmt='json')\n",
     "config.update({'detector':'XENONnT', 'right_raw_extension':50000})"
    ]
   },
@@ -410,7 +410,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.12"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,

--- a/notebooks/Understanding_WFSim_P2.ipynb
+++ b/notebooks/Understanding_WFSim_P2.ipynb
@@ -28,7 +28,7 @@
    "outputs": [],
    "source": [
     "config = straxen.get_resource('https://raw.githubusercontent.com/XENONnT/'\n",
-    "                 'strax_auxiliary_files/master/fax_files/fax_config_nt.json', fmt='json')\n",
+    "                 'strax_auxiliary_files/master/fax_files/fax_config_nt_design.json', fmt='json')\n",
     "config.update({'detector':'XENONnT'})"
    ]
   },
@@ -458,7 +458,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.12"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,

--- a/tests/test_wfsim.py
+++ b/tests/test_wfsim.py
@@ -51,7 +51,7 @@ def test_sim_nT():
             config=dict(
                 nchunk=1, event_rate=1, chunk_size=2,
                 detector='XENONnT',
-                fax_config='fax_config_nt.json',
+                fax_config='fax_config_nt_design.json',
                 **straxen.contexts.xnt_common_config),
             **straxen.contexts.common_opts)
         st.register(wfsim.RawRecordsFromFaxNT)

--- a/wfsim/strax_interface.py
+++ b/wfsim/strax_interface.py
@@ -318,7 +318,7 @@ class ChunkRawRecordsOptical(ChunkRawRecords):
                  help="Terminate processing if any one mailbox receives "
                       "no result for more than this many seconds"),
     strax.Option('fax_config',
-                 default='https://raw.githubusercontent.com/XENONnT/private_nt_aux_files/master/sim_files/fax_config_nt.json?token=AHCU5AZMPZABYSGVRLDACR3ABAZUA'),
+                 default='https://raw.githubusercontent.com/XENONnT/private_nt_aux_files/master/sim_files/fax_config_nt_design.json?token=AHCU5AZMPZABYSGVRLDACR3ABAZUA'),
     strax.Option('gain_model',
                  default=('to_pe_per_run', 'https://github.com/XENONnT/private_nt_aux_files/blob/master/sim_files/to_pe_nt.npy?raw=true'),
                  help='PMT gain model. Specify as (model_type, model_config).'),


### PR DESCRIPTION
Simplest PR ever. Default config file for nT sims has now a different name. Explanation here: https://github.com/XENONnT/private_nt_aux_files/pull/24#issuecomment-788732974

`Fax_Tutorial.ipynb` is too outdated and will anyway be renamed in #105, so I didn't touch it.