### PR TITLE
Fix non-literal compare for str

### DIFF
--- a/wfsim/strax_interface.py
+++ b/wfsim/strax_interface.py
@@ -642,7 +642,7 @@ class RawRecordsFromFaxNT(FaxSimulatorPlugin):
 
     def infer_dtype(self):
         dtype = {data_type:strax.raw_record_dtype(samples_per_record=strax.DEFAULT_RECORD_LENGTH)
-                for data_type in self.provides if data_type is not 'truth'}
+                for data_type in self.provides if data_type != 'truth'}
         dtype['truth']=instruction_dtype + truth_extra_dtype
         return dtype
 


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
```python
/home/angevaare/software/WFSim/wfsim/strax_interface.py:645: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  for data_type in self.provides if data_type is not 'truth'}
```
Fix this warning