### PR TITLE
Load GARFIELD map according to liquid level

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -44,11 +44,12 @@ def test_noise(data_length, n_channels, noise_data_length):
 def test_s2_luminescence_timings_garfield(n_positions, n_photons):
     config = dict()
     xy = np.random.uniform(-10, 10, size=[n_positions, 2])
-    shape = (len(xy), n_photons)
+    n_electrons = np.random.randint(0, 10, size=n_positions)
+    shape = (n_electrons.sum(), n_photons)
     # We just need an instance of resource and not initialization
     resource = wfsim.load_resource.Resource.__new__(wfsim.load_resource.Resource)
-    dummy_s2_luminescence = np.zeros(1000, dtype=[('x', 'f4'), ('t', 'i4')])
+    dummy_s2_luminescence = np.zeros(1000, dtype=[('x', 'f4'), ('t', 'i4', 1000)])
     dummy_s2_luminescence['x'] = np.linspace(-1, 1, 1000)
-    dummy_s2_luminescence['t'] = np.arange(1000)
+    dummy_s2_luminescence['t'] = np.random.randint(0, 10, (1000, 1000))
     resource.s2_luminescence = dummy_s2_luminescence
-    wfsim.S2.luminescence_timings_garfield(xy, shape, resource, config)
+    wfsim.S2.luminescence_timings_garfield(xy, n_electrons, shape, config=config, resource=resource)

--- a/wfsim/core.py
+++ b/wfsim/core.py
@@ -682,7 +682,7 @@ class S2(Pulse):
         distance = jagged(np.matmul(xy, rotation_mat)[:, 1])  # shortest distance from any wire
 
         index_row = [np.argmin(np.abs(d - resource.s2_luminescence['x'])) for d in distance]
-        index_row = np.repeat(index_row, n_electron)
+        index_row = np.repeat(index_row, n_electron).astype(np.int64)
         index_col = np.random.randint(0, resource.s2_luminescence['t'].shape[1], shape, np.int64)
 
         return resource.s2_luminescence['t'][index_row[:, None], index_col].astype(np.int64)

--- a/wfsim/load_resource.py
+++ b/wfsim/load_resource.py
@@ -59,7 +59,7 @@ class Resource:
                 's1_pattern_map': 'XENONnT_s1_xyz_patterns_LCE_corrected_qes_MCva43fa9b_wires.pkl',
                 's2_pattern_map': 'XENONnT_s2_xy_patterns_LCE_corrected_qes_MCva43fa9b_wires.pkl',
                 'photon_ap_cdfs': 'xnt_pmt_afterpulse_config.pkl.gz',
-                's2_luminescence': 'XENONnT_s2_garfield_luminescence_distribution_v0.pkl.gz',
+                's2_luminescence': 'XENONnT_GARFIELD_B1d5n_C30n_G1n_A6d5p_T1d5n_PMTs1d5n_FSR0d95n.npz',
                 'gas_gap_map': 'gas_gap_warping_map_January_2021.pkl',
                 'nv_pmt_qe_file': 'nveto_pmt_qe.json'
             })
@@ -148,7 +148,13 @@ class Resource:
                 self.s2_light_yield_map = lymap
 
             if config['s2_luminescence_model'] == 'garfield':
-                self.s2_luminescence = straxen.get_resource(files['s2_luminescence'], fmt='pkl.gz')
+                s2_luminescence_map = straxen.get_resource(files['s2_luminescence'], fmt='npz')
+		s2_luminescence_map = s2_luminescence_map['arr_0']
+		# Get directly the map for the simulated level
+		lls = np.arange(3.216, 6.8, 0.5) # available levels (mm)
+		ll = (config['gate_to_anode_distance'] - config['elr_gas_gap_length'])*10 # mm
+                ll = min(lls, key=lambda x:abs(x-ll))
+                self.s2_luminescence = s2_luminescence_map[s2_luminescence_map['ll']==ll]
 
             if config['field_distortion_on']:
                 self.fdc_3d = make_map(files['fdc_3d'], fmt='json.gz')

--- a/wfsim/load_resource.py
+++ b/wfsim/load_resource.py
@@ -157,8 +157,8 @@ class Resource:
                 s2_luminescence_map = straxen.get_resource(files['s2_luminescence'], fmt='npz')
                 s2_luminescence_map = s2_luminescence_map['arr_0']
                 # Get directly the map for the simulated level
-                lls = np.arange(3.216, 6.8, 0.5) # available levels (mm)
-                ll = (config['gate_to_anode_distance'] - config['elr_gas_gap_length'])*10 # mm
+                lls = np.arange(0.3216, 0.68, 0.05) # available levels (cm)
+                ll = config['gate_to_anode_distance'] - config['elr_gas_gap_length'] # cm
                 ll = min(lls, key=lambda x:abs(x-ll))
                 self.s2_luminescence = s2_luminescence_map[s2_luminescence_map['ll']==ll]
 

--- a/wfsim/load_resource.py
+++ b/wfsim/load_resource.py
@@ -154,13 +154,12 @@ class Resource:
 
             # Garfield luminescence timing samples
             if config['s2_luminescence_model'] == 'garfield':
-                s2_luminescence_map = straxen.get_resource(files['s2_luminescence'], fmt='npz')
-                s2_luminescence_map = s2_luminescence_map['arr_0']
+                s2_luminescence_map = straxen.get_resource(files['s2_luminescence'], fmt='npy')['arr_0']
                 # Get directly the map for the simulated level
-                lls = np.arange(0.3216, 0.68, 0.05) # available levels (cm)
-                ll = config['gate_to_anode_distance'] - config['elr_gas_gap_length'] # cm
-                ll = min(lls, key=lambda x:abs(x-ll))
-                self.s2_luminescence = s2_luminescence_map[s2_luminescence_map['ll']==ll]
+                liquid_level_available = np.unique(s2_luminescence_map['ll'])  # available levels (cm)
+                liquid_level = config['gate_to_anode_distance'] - config['elr_gas_gap_length']  # cm
+                liquid_level = min(liquid_level_available , key=lambda x:abs(x - liquid_level))
+                self.s2_luminescence = s2_luminescence_map[s2_luminescence_map['ll']==liquid_level]
 
             # Gas gap warping map
             if config['enable_gas_gap_warping']:

--- a/wfsim/load_resource.py
+++ b/wfsim/load_resource.py
@@ -149,10 +149,10 @@ class Resource:
 
             if config['s2_luminescence_model'] == 'garfield':
                 s2_luminescence_map = straxen.get_resource(files['s2_luminescence'], fmt='npz')
-		s2_luminescence_map = s2_luminescence_map['arr_0']
-		# Get directly the map for the simulated level
-		lls = np.arange(3.216, 6.8, 0.5) # available levels (mm)
-		ll = (config['gate_to_anode_distance'] - config['elr_gas_gap_length'])*10 # mm
+                s2_luminescence_map = s2_luminescence_map['arr_0']
+                # Get directly the map for the simulated level
+                lls = np.arange(3.216, 6.8, 0.5) # available levels (mm)
+                ll = (config['gate_to_anode_distance'] - config['elr_gas_gap_length'])*10 # mm
                 ll = min(lls, key=lambda x:abs(x-ll))
                 self.s2_luminescence = s2_luminescence_map[s2_luminescence_map['ll']==ll]
 

--- a/wfsim/strax_interface.py
+++ b/wfsim/strax_interface.py
@@ -665,11 +665,11 @@ class RawRecordsFromFaxNT(FaxSimulatorPlugin):
 
 @export
 @strax.takes_config(
-    strax.Option('wfsim_instructions',track=False,default=False),
-    strax.Option('epix_config',track=False,default=str(),
+    strax.Option('wfsim_instructions', track=False, default=False),
+    strax.Option('epix_config', track=False, default=str(),
                 help='Path to epix configuration'),
-    strax.Option('event_start',default=0,track=False,),
-    strax.Option('event_stop',default=-1,track=False,
+    strax.Option('event_start', default=0, track=False,),
+    strax.Option('event_stop', default=-1, track=False,
                 help='G4 id event number to stop at. If -1 process the entire file'),
     )
 class RawRecordsFromFaxEpix(RawRecordsFromFaxNT):
@@ -729,10 +729,10 @@ class RawRecordsFromFaxOptical(RawRecordsFromFaxNT):
 
 @export
 @strax.takes_config(
-    strax.Option('wfsim_nveto_instructions',track=False,default=False),
-    strax.Option('wfsim_nveto_channels',track=False,default=False),
-    strax.Option('wfsim_nveto_timings',track=False,default=False),
-    strax.Option('fax_config_nveto',default=None,track=True,),
+    strax.Option('wfsim_nveto_instructions', track=False, default=False),
+    strax.Option('wfsim_nveto_channels', track=False, default=False),
+    strax.Option('wfsim_nveto_timings', track=False, default=False),
+    strax.Option('fax_config_nveto', default=None, track=True,),
     )
 class RawRecordsFromFaxnVeto(RawRecordsFromFaxOptical):
     provides = ('raw_records_nv', 'truth')


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**

I pushed the changes in the `Resource` class for loading the GARFIELD maps according to the simulated liquid level, respecting the format introduced in https://github.com/XENONnT/private_nt_aux_files/pull/46. I found this was a better place than the ` luminescence_timings_garfield` function, but let me know if you disagree.

I also changed the default map to load.