### PR TITLE
conserve total quanta in tutorial

### DIFF
--- a/notebooks/Getting_started_wfsim.ipynb
+++ b/notebooks/Getting_started_wfsim.ipynb
@@ -270,8 +270,9 @@
     "                         A,\n",
     "                         Z,\n",
     "                         (1, 1))\n",
-    "        quanta.append(nc.GetQuanta(y, density).photons)\n",
-    "        quanta.append(nc.GetQuanta(y, density).electrons)\n",
+    "        q = nc.GetQuanta(y, density)\n",
+    "        quanta.append(q.photons)\n",
+    "        quanta.append(q.electrons)\n",
     "        \n",
     "    instructions['amp'] = quanta\n",
     "\n",
@@ -673,9 +674,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python [conda env:.conda-sophia]",
    "language": "python",
-   "name": "python3"
+   "name": "conda-env-.conda-sophia-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -687,7 +688,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.7"
   },
   "latex_envs": {
    "LaTeX_envs_menu_present": true,
@@ -738,5 +739,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
See issue #134 for more info. 

This is just to ensure the typo in quanta generation doesn't propagate to others' codes, namely that the generation of quanta for both photons and electrons should happen in a single step, then separated out after the fact. 