### PR TITLE
Fix nveto readout

### DIFF
--- a/wfsim/strax_interface.py
+++ b/wfsim/strax_interface.py
@@ -721,7 +721,7 @@ class RawRecordsFromMcChain(SimulatorPlugin):
                     data=result_nv[data_type.strip('_nv')],
                     data_type=data_type)
                 #If nv is not one of the targets jus return an empty chunk
-                if 'nv' in data_type:
+            if 'nv' in data_type:
                     chunk[data_type] = self.chunk(
                     start=self.sim.chunk_time_pre,
                     end=self.sim.chunk_time,

--- a/wfsim/strax_interface.py
+++ b/wfsim/strax_interface.py
@@ -725,7 +725,7 @@ class RawRecordsFromMcChain(SimulatorPlugin):
                     chunk[data_type] = self.chunk(
                     start=self.sim.chunk_time_pre,
                     end=self.sim.chunk_time,
-                    data=list(),
+                    data=np.array([]),
                     data_type=data_type)
             elif 'nv' not in data_type:
                 chunk[data_type] = self.chunk(
@@ -734,7 +734,7 @@ class RawRecordsFromMcChain(SimulatorPlugin):
                     data=result[data_type],
                     data_type=data_type)
 
-        self._sort_check([chunk[data_type].data for data_type in [self.targets[target] for target in self.config['targets']][0]])
+        self._sort_check([chunk[data_type].data for data_type in self.provides])
 
         return chunk
 

--- a/wfsim/strax_interface.py
+++ b/wfsim/strax_interface.py
@@ -720,9 +720,9 @@ class RawRecordsFromMcChain(SimulatorPlugin):
                     end=self.sim_nv.chunk_time,
                     data=result_nv[data_type.strip('_nv')],
                     data_type=data_type)
-                #If nv is not one of the targets jus return an empty chunk
+                #If nv is not one of the targets just return an empty chunk
             if 'nv' in data_type:
-                    chunk[data_type] = self.chunk(
+                chunk[data_type] = self.chunk(
                     start=self.sim.chunk_time_pre,
                     end=self.sim.chunk_time,
                     data=np.array([]),

--- a/wfsim/strax_interface.py
+++ b/wfsim/strax_interface.py
@@ -714,7 +714,7 @@ class RawRecordsFromMcChain(SimulatorPlugin):
 
         chunk = {}
         for data_type in self.provides:
-            if 'nv' in data_type:
+            if 'nveto' in self.config['targets']:
                 chunk[data_type] = self.chunk(
                     start=self.sim_nv.chunk_time_pre,
                     end=self.sim_nv.chunk_time,

--- a/wfsim/strax_interface.py
+++ b/wfsim/strax_interface.py
@@ -714,25 +714,23 @@ class RawRecordsFromMcChain(SimulatorPlugin):
 
         chunk = {}
         for data_type in self.provides:
-            if 'nv' in data_type and 'nveto' in self.config['targets']:
-                chunk[data_type] = self.chunk(
-                    start=self.sim_nv.chunk_time_pre,
-                    end=self.sim_nv.chunk_time,
-                    data=result_nv[data_type.strip('_nv')],
-                    data_type=data_type)
-                #If nv is not one of the targets just return an empty chunk
             if 'nv' in data_type:
-                chunk[data_type] = self.chunk(
-                    start=self.sim.chunk_time_pre,
-                    end=self.sim.chunk_time,
-                    data=np.array([]),
-                    data_type=data_type)
-            elif 'nv' not in data_type:
-                chunk[data_type] = self.chunk(
-                    start=self.sim.chunk_time_pre,
-                    end=self.sim.chunk_time,
-                    data=result[data_type],
-                    data_type=data_type)
+                if 'nveto' in self.config['targets']:
+                  chunk[data_type] = self.chunk(start=self.sim_nv.chunk_time_pre,
+                                                end=self.sim_nv.chunk_time,
+                                                data=result_nv[data_type.strip('_nv')],
+                                                data_type=data_type)
+                #If nv is not one of the targets just return an empty chunk
+                else:
+                  chunk[data_type] = self.chunk(start=self.sim.chunk_time_pre,
+                                                end=self.sim.chunk_time,
+                                                data=np.array([]),
+                                                data_type=data_type)
+            else:
+                chunk[data_type] = self.chunk(start=self.sim.chunk_time_pre,
+                                              end=self.sim.chunk_time,
+                                              data=result[data_type],
+                                              data_type=data_type)
 
         self._sort_check([chunk[data_type].data for data_type in self.provides])
 

--- a/wfsim/strax_interface.py
+++ b/wfsim/strax_interface.py
@@ -714,20 +714,27 @@ class RawRecordsFromMcChain(SimulatorPlugin):
 
         chunk = {}
         for data_type in self.provides:
-            if 'nveto' in self.config['targets']:
+            if 'nv' in data_type and 'nveto' in self.config['targets']:
                 chunk[data_type] = self.chunk(
                     start=self.sim_nv.chunk_time_pre,
                     end=self.sim_nv.chunk_time,
                     data=result_nv[data_type.strip('_nv')],
                     data_type=data_type)
-            else:
+                #If nv is not one of the targets jus return an empty chunk
+                if 'nv' in data_type:
+                    chunk[data_type] = self.chunk(
+                    start=self.sim.chunk_time_pre,
+                    end=self.sim.chunk_time,
+                    data=list(),
+                    data_type=data_type)
+            elif 'nv' not in data_type:
                 chunk[data_type] = self.chunk(
                     start=self.sim.chunk_time_pre,
                     end=self.sim.chunk_time,
                     data=result[data_type],
                     data_type=data_type)
 
-        self._sort_check([chunk[data_type].data for data_type in self.provides])
+        self._sort_check([chunk[data_type].data for data_type in [self.targets[target] for target in self.config['targets']][0]])
 
         return chunk
 


### PR DESCRIPTION
Missed old way to refer to writing out nv data.
nv is always in data type whether you want it or not. Use the targets option instead