### PR TITLE
Tuck load ele ap in tpc conditions

### DIFF
--- a/wfsim/load_resource.py
+++ b/wfsim/load_resource.py
@@ -143,9 +143,7 @@ class Resource:
                     files[k] = raw_url
             log.debug(f'Downloaded {k} successfully')
 
-        self.photon_area_distribution = straxen.get_resource(files['photon_area_distribution'], fmt='csv')
-
-        if config['detector'] == 'XENON1T':
+        if config.get('detector', 'XENONnT') == 'XENON1T':
             self.s1_pattern_map = make_map(files['s1_pattern_map'], fmt='json.gz')
             self.s1_light_yield_map = make_map(files['s1_light_yield_map'], fmt='json')
             self.s2_correction_map = make_map(files['s2_correction_map'], fmt='json')
@@ -212,7 +210,7 @@ class Resource:
             if config.get('enable_electron_afterpulses', False):
                 self.uniform_to_ele_ap = straxen.get_resource(files['ele_ap_pdfs'], fmt='pkl.gz')
 
-        elif config.get('detector') == 'XENONnT_neutron_veto':
+        elif config.get('detector', 'XENONnT') == 'XENONnT_neutron_veto':
             # Neutron veto PMT QE as function of wavelength
             if config.get('neutron_veto', False):
                 self.nv_pmt_qe = straxen.get_resource(files['nv_pmt_qe'], fmt='json')

--- a/wfsim/load_resource.py
+++ b/wfsim/load_resource.py
@@ -160,6 +160,10 @@ class Resource:
             if config.get('enable_pmt_afterpulses', False):
                 self.uniform_to_pmt_ap = straxen.get_resource(files['photon_ap_cdfs'], fmt='pkl.gz')
 
+            # Electron After Pulses
+            if config.get('enable_electron_afterpulses', False):
+                self.uniform_to_ele_ap = straxen.get_resource(files['ele_ap_pdfs'], fmt='pkl.gz')
+
         elif config.get('detector', 'XENONnT') == 'XENONnT':
             self.s1_pattern_map = make_map(files['s1_pattern_map'], fmt='pkl')
             if isinstance(self.s1_pattern_map, DummyMap):
@@ -204,18 +208,17 @@ class Resource:
             if config.get('enable_pmt_afterpulses', False):
                 self.uniform_to_pmt_ap = straxen.get_resource(files['photon_ap_cdfs'], fmt='json.gz')
 
-        elif config.get('detector') == 'XENONnT_neutron_veto':
+            # Electron After Pulses
+            if config.get('enable_electron_afterpulses', False):
+                self.uniform_to_ele_ap = straxen.get_resource(files['ele_ap_pdfs'], fmt='pkl.gz')
 
+        elif config.get('detector') == 'XENONnT_neutron_veto':
             # Neutron veto PMT QE as function of wavelength
             if config.get('neutron_veto', False):
                 self.nv_pmt_qe = straxen.get_resource(files['nv_pmt_qe'], fmt='json')
 
         # SPE area distributions
         self.photon_area_distribution = straxen.get_resource(files['photon_area_distribution'], fmt='csv')
-
-        # Electron After Pulses compressed, haven't figure out how pkl.gz works
-        if config.get('enable_electron_afterpulses', False):
-            self.uniform_to_ele_ap = straxen.get_resource(files['ele_ap_pdfs'], fmt='pkl.gz')
 
         # Noise sample
         if config.get('enable_noise', False):


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
When running full chain, we temporarily set the detector in config to XENONnT_neutron_veto, and won't be needing electron after pulses resource. And would get a key error when we do enable electron afterpulse. So this PR will tuck the load electron afterpulse resources under the condition detector is either XENON1T or XENONnT.
