### PR TITLE
Add tests

### DIFF
--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -33,7 +33,6 @@ jobs:
       uses: py-actions/py-dependency-install@v2
     - name: patch utilix file
       # Since we skip this step for python 3.7, we are testing without the database
-      if: matrix.python-version == 3.7 ||  matrix.python-version == 3.8
       run: bash .github/scripts/create_readonly_utilix_config.sh
       env:
         RUNDB_API_URL: ${{ secrets.RUNDB_API_URL }}

--- a/tests/test_wfsim.py
+++ b/tests/test_wfsim.py
@@ -93,6 +93,7 @@ def test_sim_nT_advanced():
         garfield s2 and noise/afterpulses. The second run will test the s1 spline model"""
     
     if not straxen.utilix_is_configured():
+        log.warning(f"Utilix is not configured, skipping database-requiring tests!")
         return
     
     with tempfile.TemporaryDirectory() as tempdir:

--- a/tests/test_wfsim.py
+++ b/tests/test_wfsim.py
@@ -92,8 +92,8 @@ def test_sim_nT_advanced():
         Clone the repo to dali and type 'pytest' to run. The first run will test simple s1,
         garfield s2 and noise/afterpulses. The second run will test the s1 spline model"""
     
-    # if not straxen.utilix_is_configured():
-    #     return
+    if not straxen.utilix_is_configured():
+        return
     
     with tempfile.TemporaryDirectory() as tempdir:
         log.debug(f'Working in {tempdir}')

--- a/tests/test_wfsim.py
+++ b/tests/test_wfsim.py
@@ -92,8 +92,8 @@ def test_sim_nT_advanced():
         Clone the repo to dali and type 'pytest' to run. The first run will test simple s1,
         garfield s2 and noise/afterpulses. The second run will test the s1 spline model"""
     
-    if not straxen.utilix_is_configured():
-        return
+    # if not straxen.utilix_is_configured():
+    #     return
     
     with tempfile.TemporaryDirectory() as tempdir:
         log.debug(f'Working in {tempdir}')
@@ -136,5 +136,3 @@ def test_sim_nT_advanced():
         p = st.get_array(run_id, 'peaks')
         _sanity_check(rr, p)
         log.info(f'All done')
-        
-


### PR DESCRIPTION
This PR adds tests. Since they require acces to the database/private_nt_aux_files you can only run them from somewhere where you do have them. But it will make life easier because it's a smaller manual step than to do it from scratch all the time.

To run them do "pytest" in the wfsim/test folder on dali

Codefactor missed the second commit for some reason