### PR TITLE
use database access to increase coverage of tests

### DIFF
--- a/.github/scripts/create_readonly_utilix_config.sh
+++ b/.github/scripts/create_readonly_utilix_config.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+if [ ! -z "$RUNDB_API_URL" ]
+then
+cat > $HOME/.xenon_config <<EOF
+[basic]
+logging_level=debug
+
+[RunDB]
+rundb_api_url = $RUNDB_API_URL
+rundb_api_user = $RUNDB_API_USER_READONLY
+rundb_api_password = $RUNDB_API_PASSWORD_READONLY
+xent_url = $PYMONGO_URL
+xent_user = $PYMONGO_USER
+xent_password = $PYMONGO_PASSWORD
+xent_database = $PYMONGO_DATABASE
+pymongo_url = $PYMONGO_URL
+pymongo_user = $PYMONGO_USER
+pymongo_password = $PYMONGO_PASSWORD
+pymongo_database = $PYMONGO_DATABASE
+
+EOF
+echo "YEAH boy, complete github actions voodoo now made you have access to our database!"
+else
+ echo "You have no power here! Environment variables are not set, therefore no utilix file will be created"
+fi

--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -31,6 +31,18 @@ jobs:
         pip install git+https://github.com/XENONnT/straxen
     - name: Install python dependencies
       uses: py-actions/py-dependency-install@v2
+    - name: patch utilix file
+        # Since we skip this step for python 3.7, we are testing without the database
+        if: matrix.python-version == 3.7 ||  matrix.python-version == 3.8
+        run: bash .github/scripts/create_readonly_utilix_config.sh
+        env:git s
+        RUNDB_API_URL: ${{ secrets.RUNDB_API_URL }}
+        RUNDB_API_USER_READONLY: ${{ secrets.RUNDB_API_USER_READONLY }}
+        RUNDB_API_PASSWORD_READONLY: ${{ secrets.RUNDB_API_PASSWORD_READONLY}}
+        PYMONGO_URL: ${{ secrets.PYMONGO_URL }}
+        PYMONGO_USER: ${{ secrets.PYMONGO_USER }}
+        PYMONGO_PASSWORD: ${{ secrets.PYMONGO_PASSWORD }}
+        PYMONGO_DATABASE: ${{ secrets.PYMONGO_DATABASE }}
     - name: Coveralls
       env:
         NUMBA_DISABLE_JIT: 1

--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -32,17 +32,17 @@ jobs:
     - name: Install python dependencies
       uses: py-actions/py-dependency-install@v2
     - name: patch utilix file
-        # Since we skip this step for python 3.7, we are testing without the database
-        if: matrix.python-version == 3.7 ||  matrix.python-version == 3.8
-        run: bash .github/scripts/create_readonly_utilix_config.sh
-        env:git s
-        RUNDB_API_URL: ${{ secrets.RUNDB_API_URL }}
-        RUNDB_API_USER_READONLY: ${{ secrets.RUNDB_API_USER_READONLY }}
-        RUNDB_API_PASSWORD_READONLY: ${{ secrets.RUNDB_API_PASSWORD_READONLY}}
-        PYMONGO_URL: ${{ secrets.PYMONGO_URL }}
-        PYMONGO_USER: ${{ secrets.PYMONGO_USER }}
-        PYMONGO_PASSWORD: ${{ secrets.PYMONGO_PASSWORD }}
-        PYMONGO_DATABASE: ${{ secrets.PYMONGO_DATABASE }}
+      # Since we skip this step for python 3.7, we are testing without the database
+      if: matrix.python-version == 3.7 ||  matrix.python-version == 3.8
+      run: bash .github/scripts/create_readonly_utilix_config.sh
+      env:git s
+      RUNDB_API_URL: ${{ secrets.RUNDB_API_URL }}
+      RUNDB_API_USER_READONLY: ${{ secrets.RUNDB_API_USER_READONLY }}
+      RUNDB_API_PASSWORD_READONLY: ${{ secrets.RUNDB_API_PASSWORD_READONLY}}
+      PYMONGO_URL: ${{ secrets.PYMONGO_URL }}
+      PYMONGO_USER: ${{ secrets.PYMONGO_USER }}
+      PYMONGO_PASSWORD: ${{ secrets.PYMONGO_PASSWORD }}
+      PYMONGO_DATABASE: ${{ secrets.PYMONGO_DATABASE }}
     - name: Coveralls
       env:
         NUMBA_DISABLE_JIT: 1

--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -35,14 +35,14 @@ jobs:
       # Since we skip this step for python 3.7, we are testing without the database
       if: matrix.python-version == 3.7 ||  matrix.python-version == 3.8
       run: bash .github/scripts/create_readonly_utilix_config.sh
-      env:git s
-      RUNDB_API_URL: ${{ secrets.RUNDB_API_URL }}
-      RUNDB_API_USER_READONLY: ${{ secrets.RUNDB_API_USER_READONLY }}
-      RUNDB_API_PASSWORD_READONLY: ${{ secrets.RUNDB_API_PASSWORD_READONLY}}
-      PYMONGO_URL: ${{ secrets.PYMONGO_URL }}
-      PYMONGO_USER: ${{ secrets.PYMONGO_USER }}
-      PYMONGO_PASSWORD: ${{ secrets.PYMONGO_PASSWORD }}
-      PYMONGO_DATABASE: ${{ secrets.PYMONGO_DATABASE }}
+      env:
+        RUNDB_API_URL: ${{ secrets.RUNDB_API_URL }}
+        RUNDB_API_USER_READONLY: ${{ secrets.RUNDB_API_USER_READONLY }}
+        RUNDB_API_PASSWORD_READONLY: ${{ secrets.RUNDB_API_PASSWORD_READONLY}}
+        PYMONGO_URL: ${{ secrets.PYMONGO_URL }}
+        PYMONGO_USER: ${{ secrets.PYMONGO_USER }}
+        PYMONGO_PASSWORD: ${{ secrets.PYMONGO_PASSWORD }}
+        PYMONGO_DATABASE: ${{ secrets.PYMONGO_DATABASE }}
     - name: Coveralls
       env:
         NUMBA_DISABLE_JIT: 1

--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -35,17 +35,17 @@ jobs:
         run: |
           pip install git+https://github.com/XENONnT/straxen
       - name: patch utilix file
-          # Since we skip this step for python 3.7, we are testing without the database
-          if: matrix.python-version == 3.7 ||  matrix.python-version == 3.8
-          run: bash .github/scripts/create_readonly_utilix_config.sh
-          env:
-            RUNDB_API_URL: ${{ secrets.RUNDB_API_URL }}
-            RUNDB_API_USER_READONLY: ${{ secrets.RUNDB_API_USER_READONLY }}
-            RUNDB_API_PASSWORD_READONLY: ${{ secrets.RUNDB_API_PASSWORD_READONLY}}
-            PYMONGO_URL: ${{ secrets.PYMONGO_URL }}
-            PYMONGO_USER: ${{ secrets.PYMONGO_USER }}
-            PYMONGO_PASSWORD: ${{ secrets.PYMONGO_PASSWORD }}
-            PYMONGO_DATABASE: ${{ secrets.PYMONGO_DATABASE }}
+        # Since we skip this step for python 3.7, we are testing without the database
+        if: matrix.python-version == 3.7 ||  matrix.python-version == 3.8
+        run: bash .github/scripts/create_readonly_utilix_config.sh
+        env:
+          RUNDB_API_URL: ${{ secrets.RUNDB_API_URL }}
+          RUNDB_API_USER_READONLY: ${{ secrets.RUNDB_API_USER_READONLY }}
+          RUNDB_API_PASSWORD_READONLY: ${{ secrets.RUNDB_API_PASSWORD_READONLY}}
+          PYMONGO_URL: ${{ secrets.PYMONGO_URL }}
+          PYMONGO_USER: ${{ secrets.PYMONGO_USER }}
+          PYMONGO_PASSWORD: ${{ secrets.PYMONGO_PASSWORD }}
+          PYMONGO_DATABASE: ${{ secrets.PYMONGO_DATABASE }}
       - name: Install python dependencies
         uses: py-actions/py-dependency-install@v2
       - name: Do the test

--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -49,8 +49,6 @@ jobs:
       - name: Install python dependencies
         uses: py-actions/py-dependency-install@v2
       - name: Do the test
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-            python setup.py test
+        run: python setup.py test
       - name: goodbye
         run: echo goodbye

--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -17,13 +17,13 @@ on:
       - master
 
 jobs:
-  test_wfsim:
-    runs-on: ${{ matrix.os }}
+   name: test_wfsim
+    runs-on: ubuntu-latest
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
-        os: ["ubuntu-latest"]
-        python-version: ["3.8"]
+        # NB: For python3.6 we are going to explicitly test without a database
+        python-version: [3.6, 3.7, 3.8]
     steps:
       - name: Setup python
         uses: actions/setup-python@v2 # https://github.com/marketplace/actions/setup-miniconda
@@ -34,6 +34,18 @@ jobs:
       - name: Install dependencies
         run: |
           pip install git+https://github.com/XENONnT/straxen
+      - name: patch utilix file
+          # Since we skip this step for python 3.7, we are testing without the database
+          if: matrix.python-version == 3.7 ||  matrix.python-version == 3.8
+          run: bash .github/scripts/create_readonly_utilix_config.sh
+          env:git s
+            RUNDB_API_URL: ${{ secrets.RUNDB_API_URL }}
+            RUNDB_API_USER_READONLY: ${{ secrets.RUNDB_API_USER_READONLY }}
+            RUNDB_API_PASSWORD_READONLY: ${{ secrets.RUNDB_API_PASSWORD_READONLY}}
+            PYMONGO_URL: ${{ secrets.PYMONGO_URL }}
+            PYMONGO_USER: ${{ secrets.PYMONGO_USER }}
+            PYMONGO_PASSWORD: ${{ secrets.PYMONGO_PASSWORD }}
+            PYMONGO_DATABASE: ${{ secrets.PYMONGO_DATABASE }}
       - name: Install python dependencies
         uses: py-actions/py-dependency-install@v2
       - name: Do the test

--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -17,7 +17,7 @@ on:
       - master
 
 jobs:
-    name: test_wfsim
+  test_wfsim:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true
@@ -26,7 +26,7 @@ jobs:
         python-version: [3.6, 3.7, 3.8]
     steps:
       - name: Setup python
-        uses: actions/setup-python@v2 # https://github.com/marketplace/actions/setup-miniconda
+        uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
       - name: Checkout repo

--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -38,7 +38,7 @@ jobs:
           # Since we skip this step for python 3.7, we are testing without the database
           if: matrix.python-version == 3.7 ||  matrix.python-version == 3.8
           run: bash .github/scripts/create_readonly_utilix_config.sh
-          env:git s
+          env:
             RUNDB_API_URL: ${{ secrets.RUNDB_API_URL }}
             RUNDB_API_USER_READONLY: ${{ secrets.RUNDB_API_USER_READONLY }}
             RUNDB_API_PASSWORD_READONLY: ${{ secrets.RUNDB_API_PASSWORD_READONLY}}

--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -17,7 +17,7 @@ on:
       - master
 
 jobs:
-   name: test_wfsim
+    name: test_wfsim
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -3,3 +3,6 @@
 **WFSim needs you:**
  - Please add a test for this PR, as a bare minimum, make sure it's covered in coveralls!
  - Can you add a docsting to all your functions?
+
+*Pay attention:*
+ - Due to databases being needed for testing, making a PR from your own fork will typically NOT run the tests. If you then merge master might break


### PR DESCRIPTION
# What is the problem / what does the code in this PR do
This PR allows WFSim to pull configs form the database in order to be fully tested. This should increase the coverage and make it easier for the developers to spot potential issues as github actions would work just as well as doing local tests.

For example #152 will be much more useful if this PR is merged.

## Developer commitment required
There is a caveat which the developers should be aware of since this will cause work (less then in the current state but still, they are the ones in charge to fix those things).

In order to have the test also being able to run from a remote fork, the tests need to (stay) drafted as if there is a possibility that one does not have access to the database. We make sure this is the case using the famous line:
```python
   if not straxen.utilix_is_configured():
        return
```

The developers should be consent that this will (almost guaranteed) cause confusion if one makes a PR from their own fork, merge it, and the tests fail. Since on ones fork, there was no database access, on master there is, running a new test, which might fail. The developers need to explain/fix this after the PR merge. This perhaps sounds more complex than it actually is. After all, if one reviews it properly there should be no bugs right :wink:? Also keep in mind that with the addition of this PR, you actually find this out immediately whereas in the current state, you would only notice errors when running locally. 