### PR TITLE
Following up the change in pmt ap file

### DIFF
--- a/tests/test_wfsim.py
+++ b/tests/test_wfsim.py
@@ -23,7 +23,7 @@ def test_sim_1T():
         log.debug(f'Working in {tempdir}')
         testing_config_1T = dict(
             hev_gain_model=('to_pe_constant', 0.0085),
-            gain_model=('to_pe_constant', 0.0085)
+            gain_model=('to_pe_constant', 0.0085),
         )
         st = strax.Context(
             storage=tempdir,
@@ -31,7 +31,10 @@ def test_sim_1T():
                 nchunk=2, event_rate=1, chunk_size=1,
                 detector='XENON1T',
                 fax_config=('https://raw.githubusercontent.com/XENONnT/strax_auxiliary_files'
-                    '/f4ea367122f45d1ae0e90e57005a77fef7df8a2c/sim_files/fax_config_1t.json'),  # noqa
+                    '/c76f30ad20516efbcc832c97842abcba743f0017/sim_files/fax_config_1t.json'),  # noqa
+                fax_config_override=dict(
+                    url_base=("https://raw.githubusercontent.com/XENONnT/strax_auxiliary_files"
+                              "/c76f30ad20516efbcc832c97842abcba743f0017/sim_files/"),),
                 **straxen.contexts.x1t_common_config),
             **straxen.contexts.common_opts)
         st.register(wfsim.RawRecordsFromFax1T)

--- a/wfsim/core.py
+++ b/wfsim/core.py
@@ -1147,6 +1147,9 @@ class PMT_Afterpulse(Pulse):
             delaytime_cdf = resource.uniform_to_pmt_ap[element]['delaytime_cdf']
             amplitude_cdf = resource.uniform_to_pmt_ap[element]['amplitude_cdf']
 
+            delaytime_bin_size = resource.uniform_to_pmt_ap[element]['delaytime_bin_size']
+            amplitude_bin_size = resource.uniform_to_pmt_ap[element]['amplitude_bin_size']
+
             # Assign each photon FRIST random uniform number rU0 from (0, 1] for timing
             rU0 = 1 - np.random.rand(len(signal_pulse._photon_timings))
 
@@ -1162,25 +1165,26 @@ class PMT_Afterpulse(Pulse):
 
             # The map is made so that the indices are delay time in unit of ns
             if 'Uniform' in element:
-                ap_delay = np.random.uniform(delaytime_cdf[sel_photon_channel, 0], 
+                ap_delay = (np.random.uniform(delaytime_cdf[sel_photon_channel, 0], 
                                              delaytime_cdf[sel_photon_channel, 1])
+                            * delaytime_bin_size)
                 ap_amplitude = np.ones_like(ap_delay)
             else:
                 ap_delay = (np.argmin(
                     np.abs(
                         delaytime_cdf[sel_photon_channel]
-                        - rU0[sel_photon_id][:, None]), axis=-1)
+                        - rU0[sel_photon_id][:, None]), axis=-1) * delaytime_bin_size
                             - config['pmt_ap_t_modifier'])
                 if len(amplitude_cdf.shape) == 2:
                     ap_amplitude = np.argmin(
                         np.abs(
                             amplitude_cdf[sel_photon_channel]
-                            - rU1[:, None]), axis=-1) / 100.
+                            - rU1[:, None]), axis=-1) * amplitude_bin_size
                 else:
                     ap_amplitude = np.argmin(
                         np.abs(
                             amplitude_cdf[None, :]
-                            - rU1[:, None]), axis=-1) / 100.
+                            - rU1[:, None]), axis=-1) * amplitude_bin_size
 
             _photon_timings.append(signal_pulse._photon_timings[sel_photon_id] + ap_delay)
             _photon_channels.append(signal_pulse._photon_channels[sel_photon_id])


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
Following up on https://github.com/XENONnT/private_nt_aux_files/pull/56, bin sizes are added to the pmt afterpulsing file. Here we change the hardcoded bin size to the ones saved in the resource file.

TODO:
~Update this file for XENON1T~
