### PR TITLE
Fix #157 for empty files

### DIFF
--- a/wfsim/load_resource.py
+++ b/wfsim/load_resource.py
@@ -182,6 +182,11 @@ class Resource:
                 continue
             if k == 'url_base':
                 continue
+            if v == '':
+                log.warning(f'{k} has no path so this config file is set to None')
+                files[k] = None
+                continue
+
             log.debug(f'Obtaining {k} from {v}')
             files[k] = self.get_file_path(files['url_base'], v)
 


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
For [empty configs like this](https://github.com/XENONnT/WFSim/blob/c2d1f17551ab7954fa5def83b3ff810de91ed3ef/wfsim/load_resource.py#L93) we cannot summon files out of thin air 🧙 . Therefore, we just need to skip those. Otherwise we are going to try loading things from places we are sure we cannot find them.

### Failing?
Lets wait for #159 to be merged, then should be fine again.

