### PR TITLE
Patch 1T custom context

### DIFF
--- a/tests/test_wfsim.py
+++ b/tests/test_wfsim.py
@@ -41,7 +41,8 @@ def test_sim_1T():
                     url_base=("https://raw.githubusercontent.com/XENONnT/strax_auxiliary_files"
                               "/c76f30ad20516efbcc832c97842abcba743f0017/sim_files/"),),
                 **straxen.contexts.x1t_common_config),
-            **straxen.contexts.common_opts)
+            **straxen.contexts.x1t_context_config,
+        )
         st.register(wfsim.RawRecordsFromFax1T)
         log.debug(f'Setting testing config {testing_config_1T}')
         st.set_config(testing_config_1T)


### PR DESCRIPTION
## What is the problem / what does the code in this PR do
In https://github.com/AxFoundation/strax/pull/440 I made the context a bit more strict on the allowed config options. If one says that per-run-defaults are not allowed, we can get great speed improvement.

However, if you use 1T plugins (with per run defaults) this will cause errors:
See e.g. the base env:
https://travis-ci.org/github/XENONnT/base_environment/builds/771769395


## Solution
As such, we need be explicit that it is ok to use per run defaults for 1T simulation.