### PR TITLE
Introducing sorting by channel number to preserve timing in S1s

### DIFF
--- a/wfsim/core.py
+++ b/wfsim/core.py
@@ -328,6 +328,11 @@ class S1(Pulse):
                                                    channels=self._photon_channels,
                                                    positions = positions,
                                                    resource=self.resource )
+        # Sorting times according to the channel, as non-explicit sorting
+        # is performed later and this breaks timing of individual channels/arrays
+        sortind = np.argsort(self._photon_channels)
+        self._photon_channels = self._photon_channels[sortind]
+        self._photon_timings = self._photon_timings[sortind]
         super().__call__()
 
     @staticmethod


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
If each channel/array has individual timing distribution, it will be effectively scrambled due to call of `unique` function here: https://github.com/XENONnT/WFSim/blob/s1_ch_sorting/wfsim/core.py#L75 . 

To avoid this unwanted behavior, explicit sorting is performed in S1 class. 
