### PR TITLE
Straxen 0.19.0 is bugged

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 strax
 utilix>=0.5.3
-straxen>=0.19.0
+straxen>=0.19.1
 uproot>=4.0.0


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
Straxen 0.19.0 is bugged and shouldn't be used, see e.g. the current failing test on master
