### PR TITLE
Fix the 0.5% bias in gain sampling

### DIFF
--- a/wfsim/core.py
+++ b/wfsim/core.py
@@ -264,11 +264,11 @@ class Pulse(object):
                 tmp_photon_timing = photon_timings[i]
             else:
                 gain_total += photon_gains[i]
-        else:
-            start = int(tmp_photon_timing // dt) - pulse_left
-            reminder = int(tmp_photon_timing % dt)
-            pulse_current[start:start + template_length] += \
-                pmt_current_templates[reminder] * gain_total
+
+        start = int(tmp_photon_timing // dt) - pulse_left
+        reminder = int(tmp_photon_timing % dt)
+        pulse_current[start:start + template_length] += \
+            pmt_current_templates[reminder] * gain_total
 
     @staticmethod
     def singlet_triplet_delays(size, singlet_ratio, config, phase):

--- a/wfsim/core.py
+++ b/wfsim/core.py
@@ -206,7 +206,8 @@ class Pulse(object):
                 scaled_bins = np.zeros_like(cdf)
 
             grid_cdf = np.linspace(0, 1, 2001)
-            grid_scale = interp1d(cdf, scaled_bins, 
+            grid_scale = interp1d(cdf, scaled_bins,
+                                  kind='next',
                                   bounds_error=False,
                                   fill_value=(scaled_bins[0], scaled_bins[-1]))(grid_cdf)
 


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
@dantonmartin had reported a very small negative bias even with noise disabled. This is caused by that the interpolation on inverse survival function (isf) of the SPE spectrum returns value shifted down by half a bin size (0.01 PE) of the input SPE spectrum which is 0.005 (PE).

This pr will use 'next' to interpolate the isf, so that we can get back exactly the distribution of the input spectrum. (But we do lose sub 0.01 PE resolution, which is acceptable)
