### PR TITLE
Use real noise

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -30,13 +30,13 @@ def test_noise(data_length, n_channels, noise_data_length):
     # Take a copy of the channel mask
     channel_mask = channel_mask[:n_channels]
     # Noise is a string with random floats
-    noise_data = np.random.randint(-10, 10, size=noise_data_length).astype(np.float64)
+    noise_data = np.random.randint(-10, 10, size=(noise_data_length, n_channels)).astype(np.float64)
 
     RawData = wfsim.RawData
     noise_function = RawData.add_noise
 
     # Actually test that we can run the function
-    noise_function(data, channel_mask, noise_data, noise_data_length)
+    noise_function(data, channel_mask, noise_data, noise_data_length, n_channels)
 
 @settings(max_examples=100, deadline=None)
 @given(strategies.integers(min_value=0, max_value=100),

--- a/wfsim/core/rawdata.py
+++ b/wfsim/core/rawdata.py
@@ -248,12 +248,14 @@ class RawData(object):
             self._channel_mask['right'] -= self.left - self.config['trigger_window']
 
             # Adding noise, baseline and digitizer saturation
-            
+
             if self.config.get('enable_noise', True):
                 self.add_noise(data=self._raw_data,
                                channel_mask=self._channel_mask,
                                noise_data=self.resource.noise_data,
-                               noise_data_length=len(self.resource.noise_data))
+                               noise_data_length=len(self.resource.noise_data),
+                               noise_data_channels=len(self.resource.noise_data[0]))
+
             self.add_baseline(self._raw_data, self._channel_mask, 
                               self.config['digitizer_reference_baseline'],)
             self.digitizer_saturation(self._raw_data, self._channel_mask)
@@ -373,20 +375,37 @@ class RawData(object):
 
     @staticmethod
     @njit
-    def add_noise(data, channel_mask, noise_data, noise_data_length):
+    def add_noise(data, channel_mask, noise_data, noise_data_length, noise_data_channels):
         """
         Get chunk(s) of noise sample from real noise data
         """
+        left = np.min(channel_mask['left'][channel_mask['mask']])
+        right = np.max(channel_mask['right'][channel_mask['mask']])
+
+        if noise_data_length-right+left-1 < 0:
+            ix_rand = np.random.randint(low=0, high=noise_data_length-1)
+        else:
+            ix_rand = np.random.randint(low=0, high=noise_data_length-right+left-1)
+
         for ch in range(data.shape[0]):
+            # In case adding noise to he channels is not supported
+            if ch >= noise_data_channels:
+                continue
+
             if not channel_mask['mask'][ch]:
                 continue
+
             left, right = channel_mask['left'][ch], channel_mask['right'][ch]
-            id_t = np.random.randint(low=0, high=noise_data_length-right+left)
-            for ix in range(left, right+1):
-                if id_t+ix >= noise_data_length or ix >= len(data[ch]):
+            for ix_data in range(left, right+1):
+                ix_noise = ix_rand + ix_data - left
+                if ix_data >= len(data[ch]):
                     # Don't create value-errors
                     continue
-                data[ch, ix] += noise_data[id_t+ix]
+
+                if ix_noise >= noise_data_length:
+                    ix_noise -= noise_data_length * (ix_noise // noise_data_length)
+
+                data[ch, ix_data] += noise_data[ix_noise, ch]
 
     @staticmethod
     @njit

--- a/wfsim/core/rawdata.py
+++ b/wfsim/core/rawdata.py
@@ -379,6 +379,9 @@ class RawData(object):
         """
         Get chunk(s) of noise sample from real noise data
         """
+        if channel_mask['mask'].sum() == 0:
+            return
+
         left = np.min(channel_mask['left'][channel_mask['mask']])
         right = np.max(channel_mask['right'][channel_mask['mask']])
 

--- a/wfsim/load_resource.py
+++ b/wfsim/load_resource.py
@@ -276,7 +276,9 @@ class Resource:
 
         # Noise sample
         if config.get('enable_noise', False):
-            self.noise_data = straxen.get_resource(files['noise_file'], fmt='npy')['arr_0'].flatten()
+            self.noise_data = straxen.get_resource(files['noise_file'], fmt='npy')['arr_0']
+            n_channels = len(self.noise_data[0])
+            log.warning(f'Using noise data {files["noise_file"]} with {n_channels} channels for {config["detector"]}')
 
         log.debug(f'{self.__class__.__name__} fully initialized')
 


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
Remove the temporary measure of flattering noise sample from XENON1T for XENONnT. So with the proper noise file, the noise would be sampled from individual channels instead of mixing all together.