### PR TITLE
Fix optical readout

### DIFF
--- a/tests/test_contexts.py
+++ b/tests/test_contexts.py
@@ -17,7 +17,7 @@ def test_nt_context(register=None, context=None):
         return
 
     if context is None:
-        context = straxen.contexts.xenonnt_simulation()
+        context = straxen.contexts.xenonnt_simulation(cmt_run_id_sim='010000')
     assert isinstance(context, strax.Context), f'{context} is not a context'
 
     if register is not None:

--- a/tests/test_wfsim.py
+++ b/tests/test_wfsim.py
@@ -124,7 +124,7 @@ def test_sim_nT_advanced():
 
     with tempfile.TemporaryDirectory() as tempdir:
         log.debug(f'Working in {tempdir}')
-        st = straxen.contexts.xenonnt_simulation()
+        st = straxen.contexts.xenonnt_simulation(cmt_run_id_sim='010000')
         st.set_config(dict(nchunk=1, event_rate=1, chunk_size=2,))
 
         st.set_config({'fax_config_override': dict(s2_luminescence_model='simple',
@@ -156,7 +156,7 @@ def test_sim_mc_chain():
         with open('test.root', mode='wb') as f:
             f.write(url_data)
 
-        st = straxen.contexts.xenonnt_simulation()
+        st = straxen.contexts.xenonnt_simulation(cmt_run_id_sim='010000')
 
         epix_config = {'cut_by_eventid': True, 'debug': True, 'source_rate': 0, 'micro_separation_time': 10.,
                        'max_delay': 1e7, 'detector_config_override': None, 'micro_separation': 0.05,

--- a/tests/test_wfsim.py
+++ b/tests/test_wfsim.py
@@ -112,7 +112,7 @@ def test_sim_nT_advanced():
 
     with tempfile.TemporaryDirectory() as tempdir:
         log.debug(f'Working in {tempdir}')
-        st = straxen.contexts.xenonnt_simulation()
+        st = straxen.contexts.xenonnt_simulation(cmt_run_id_sim='010000')
         st.set_config(dict(nchunk=1, event_rate=1, chunk_size=2,))
 
         log.debug(f'Getting raw-records')

--- a/wfsim/utils.py
+++ b/wfsim/utils.py
@@ -66,6 +66,12 @@ def find_optical_t_range(firsts, lasts, timings, tmins, tmaxs, start=0):
     """
     
     for ix in range(start, len(firsts)):
+        if firsts[ix] == lasts[ix]:
+           tmins[ix] = -1
+           tmaxs[ix] = -1
+           # No photons in this instruction
+           continue
+
         tmin = timings[firsts[ix]]
         tmax = timings[firsts[ix]]
         for iy in range(firsts[ix], lasts[ix]):

--- a/wfsim/utils.py
+++ b/wfsim/utils.py
@@ -145,6 +145,7 @@ def optical_adjustment(instructions, timings, channels):
             tmp = deepcopy(instructions[ix])
             tmp['_first'] = first
             tmp['_last'] = last
+            instructions[ix]['_first']=last
 
             extra_inst.append(tmp)
 

--- a/wfsim/utils.py
+++ b/wfsim/utils.py
@@ -142,10 +142,10 @@ def optical_adjustment(instructions, timings, channels):
                                                         timings,
                                                         channels):
 
-            tmp = deepcopy(instructions[ix])
+            tmp = deepcopy(instructions[np.where(long_pulse)[0][ix]])
             tmp['_first'] = first
             tmp['_last'] = last
-            instructions[ix]['_first']=last
+            instructions[np.where(long_pulse)[0][ix]]['_first']=last
 
             extra_inst.append(tmp)
 


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
In optical_adjustment we split peaks if they are too long, adding a new instruction for the remainder. However there is a mistake causing the split peak to not be split and the remainer to be still added afterwards

This fixes the splitting function
