### PR TITLE
Bug fix for wrong place to write dtype of numpy array for empty return case

### DIFF
--- a/wfsim/strax_interface.py
+++ b/wfsim/strax_interface.py
@@ -767,8 +767,8 @@ class RawRecordsFromMcChain(SimulatorPlugin):
                                                 data=np.array([], dtype=dummy_dtype),
                                                 data_type=data_type)
                     else:
-                        chunk[data_type] = self.chunk(start=0, end=0, data=np.array([]),
-                                                  data_type=data_type, dtype=dummy_dtype)
+                        chunk[data_type] = self.chunk(start=0, end=0, data=np.array([], dtype=dummy_dtype),
+                                                  data_type=data_type)
             else:
                 if exist_tpc_result:
                     chunk[data_type] = self.chunk(start=self.sim.chunk_time_pre,


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
I'm really sorry to forget to push the last bug fix.
