### PR TITLE
Introduce additional parameter to spread SPE distribution

### DIFF
--- a/wfsim/core/pulse.py
+++ b/wfsim/core/pulse.py
@@ -176,7 +176,7 @@ class Pulse(object):
                 # mean_spe = (spe_shapes['charge'].values * spe_shapes[ch]).sum() / spe_shapes[ch].sum()
                 scaled_bins = spe_shapes['charge'].values  # / mean_spe
                 spe_shape = self.apply_additional_spread(scaled_bins, spe_shapes[ch])
-                cdf = np.cumsum(spe_shapes) / np.sum(spe_shape)
+                cdf = np.cumsum(spe_shape) / np.sum(spe_shape)
             else:
                 # if sum is 0, just make some dummy axes to pass to interpolator
                 cdf = np.linspace(0, 1, 10)


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**

For neutron Veto, template pulse and SPE distributions are implemented. However, the generated SPE distributions and template pulses reproduce  `area` of `hitlets_nv` but not perfectly `amplitude` and others.
It might come from WFSim assumption: all pulse can be reproduced sum of SPE template pulse * gain with spread. In fact some pulses spread with vertical axis (time) because of the time spread of charge reaching timings.

I tried to fix the two parameters, `area` and `amplitude` with one additional spread parameter (`additional_spe_spread_charge`), which is sigma of gaussian distribution with unit of charge.

![image](https://user-images.githubusercontent.com/12980386/135992311-9829f2f4-990b-4170-8fda-d2bd936a9036.png)
