### PR TITLE
Change to online cmt version

### DIFF
--- a/tests/test_contexts.py
+++ b/tests/test_contexts.py
@@ -17,7 +17,7 @@ def test_nt_context(register=None, context=None):
         return
 
     if context is None:
-        context = straxen.contexts.xenonnt_simulation(cmt_run_id_sim='010000')
+        context = straxen.contexts.xenonnt_simulation(cmt_run_id_sim='010000', cmt_version='ONLINE')
     assert isinstance(context, strax.Context), f'{context} is not a context'
 
     if register is not None:

--- a/tests/test_wfsim.py
+++ b/tests/test_wfsim.py
@@ -112,7 +112,9 @@ def test_sim_nT_advanced():
 
     with tempfile.TemporaryDirectory() as tempdir:
         log.debug(f'Working in {tempdir}')
-        st = straxen.contexts.xenonnt_simulation(cmt_run_id_sim='010000', _config_overlap={},)
+        st = straxen.contexts.xenonnt_simulation(cmt_run_id_sim='010000',
+                                                 cmt_version='ONLINE',
+                                                 _config_overlap={},)
         st.set_config(dict(gain_model_mc=("to_pe_placeholder", True),
                            gain_model=("to_pe_placeholder", True),
                            hit_min_amplitude='pmt_commissioning_initial'
@@ -148,7 +150,9 @@ def test_sim_mc_chain():
         url_data = requests.get(test_g4).content
         with open('test.root', mode='wb') as f:
             f.write(url_data)
-        st = straxen.contexts.xenonnt_simulation(cmt_run_id_sim='010000', _config_overlap={},)
+        st = straxen.contexts.xenonnt_simulation(cmt_run_id_sim='010000',
+                                                 cmt_version='ONLINE',
+                                                 _config_overlap={},)
         st.set_config(dict(gain_model_mc=("to_pe_placeholder", True),
                            gain_model=("to_pe_placeholder", True),
                            gain_model_nv=("adc_nv", True),


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
The older CMT version is deprecated for the straxen v1.1.1, we now use the online version in the tests instead.