### PR TITLE
Fix nVeto dtypes handling in RawRecordsFromMcChain

### DIFF
--- a/wfsim/strax_interface.py
+++ b/wfsim/strax_interface.py
@@ -855,8 +855,9 @@ class RawRecordsFromMcChain(SimulatorPlugin):
         exist_tpc_result, exist_nveto_result = False, False
         for data_type in self.provides:
             if 'nv' in data_type:
-                if len(result_nv[data_type.strip('_nv')]) > 0:
-                    exist_nveto_result = True
+                if 'nveto' in self.config['targets']:
+                    if len(result_nv[data_type.strip('_nv')]) > 0:
+                        exist_nveto_result = True
             else:
                 if len(result[data_type]) > 0:
                     exist_tpc_result = True


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**

Loop over nVeto data types only when `nveto` is one of the targets to simulate, otherwise we run into errors when using the mc_chain context with nVeto set to false: we're requesting `result_nv` without having defined it earlier (because `nveto` it's not in targets), while the `RawRecordsFromMcChain` plugin provides with all data types for nVeto and TPC.