### PR TITLE
Exclude DPE from n_photon in truth

### DIFF
--- a/wfsim/core/rawdata.py
+++ b/wfsim/core/rawdata.py
@@ -343,7 +343,7 @@ class RawData(object):
                 * self.config['sample_duration']
 
         channels = getattr(pulse, '_photon_channels', [])
-        if self.config.get('exclude_dpe_in_truth', False):
+        if self.config.get('exclude_dpe_in_truth', True):
             n_dpe = n_dpe_bot = 0
         else:
             n_dpe = getattr(pulse, '_n_double_pe', 0)


### PR DESCRIPTION
Currently `n_photon` in the truth output of WFSim is not actually a number of photons, but a number of photoelectrons emitted from the PMT photocathodes. This is fine as an option, but I think it should not be the default since it isn't quite accurate. After this PR, `n_photon` would refer to the number of photons detected by PMTs (making at least one PE at the photocathode).