### PR TITLE
up py version

### DIFF
--- a/.github/workflows/Pipi.yml
+++ b/.github/workflows/Pipi.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.6'
+          python-version: '3.8'
       - name: Checkout repo
         uses: actions/checkout@v2
       - name: Install dependencies

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -32,13 +32,17 @@ jobs:
     strategy:
       fail-fast: True
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: [3.8, 3.9, "3.10"]
         test: ['coveralls', 'pytest', 'pytest_no_database']
         # Only run coverage / no_database on py3.8
         exclude:
           - python-version: 3.9
             test: coveralls
           - python-version: 3.9
+            test: pytest_no_database
+          - pytest-version: "3.10"
+            test: coveralls
+          - pytest-version: "3.10"
             test: pytest_no_database
     steps:
       # Setup and installation

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -54,7 +54,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Install requirements for tests and latest strax
         run: |
-            pip install-r git+https://github.com/NESTCollaboration/nestpy.git@v1.5.0
+            pip install -r git+https://github.com/NESTCollaboration/nestpy.git@v1.5.0
             pip install -r extra_requirements/requirements-tests.txt
       # Secrets and required files
       - name: patch utilix file

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -37,8 +37,6 @@ jobs:
         # Only run coverage / no_database on py3.8
         exclude:
           - python-version: 3.9
-            test: coveralls
-          - python-version: 3.9
             test: pytest_no_database
           - python-version: "3.10"
             test: coveralls
@@ -54,7 +52,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Install requirements for tests and latest strax
         run: |
-            pip install -r git+https://github.com/NESTCollaboration/nestpy.git@v1.5.0
+            pip install git+https://github.com/NESTCollaboration/nestpy.git@v1.5.0
             pip install -r extra_requirements/requirements-tests.txt
       # Secrets and required files
       - name: patch utilix file

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -40,7 +40,7 @@ jobs:
             test: coveralls
           - python-version: 3.9
             test: pytest_no_database
-          - pytest-version: "3.10"
+          - python-version: "3.10"
             test: coveralls
           - pytest-version: "3.10"
             test: pytest_no_database

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -32,16 +32,12 @@ jobs:
     strategy:
       fail-fast: True
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9]
         test: ['coveralls', 'pytest', 'pytest_no_database']
         # Only run coverage / no_database on py3.8
         exclude:
-          - python-version: 3.7
-            test: coveralls
           - python-version: 3.9
             test: coveralls
-          - python-version: 3.7
-            test: pytest_no_database
           - python-version: 3.9
             test: pytest_no_database
     steps:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -54,6 +54,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Install requirements for tests and latest strax
         run: |
+            pip install-r git+https://github.com/NESTCollaboration/nestpy.git@v1.5.0
             pip install -r extra_requirements/requirements-tests.txt
       # Secrets and required files
       - name: patch utilix file

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -42,7 +42,7 @@ jobs:
             test: pytest_no_database
           - python-version: "3.10"
             test: coveralls
-          - pytest-version: "3.10"
+          - python-version: "3.10"
             test: pytest_no_database
     steps:
       # Setup and installation

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,7 +10,7 @@ build:
     image: latest
 
 python:
-    version: 3.6
+    version: 3.8
     install:
       - method: pip
         path: .

--- a/extra_requirements/requirements-tests.txt
+++ b/extra_requirements/requirements-tests.txt
@@ -18,22 +18,25 @@ holoviews==1.14.5
 ipywidgets==7.6.4
 hypothesis==6.36.1
 jupyter-client==7.1.2                          # for ipywidgets
+keras==2.8.0; python_version<="3.9"             # Tensorflow dependency
+keras==2.8.0rc1; python_version=="3.10"         # Tensorflow dependency
 matplotlib==3.5.1
-multihist==0.6.4
+multihist==0.6.5
 nestpy==1.5.0; python_version<="3.9"
 git+https://github.com/NESTCollaboration/nestpy.git; python_version=="3.10"
 npshmex==0.2.1                                  # Strax dependency
 numba==0.55.1                                   # Strax dependency
 numpy==1.21.5
 nestpy==1.5.0
-pandas==1.3.5                                   # Strax dependency
+pandas==1.4.0                                   # Strax dependency
 psutil==5.9.0                                   # Strax dependency
 pytest==6.2.5
 pytest-cov==3.0.0
 pymongo==3.12.0                                 # Strax dependency
 scikit-learn==1.0.2
 scipy==1.7.3                                    # Strax dependency
-tensorflow==2.7.0
+tensorflow==2.8.0rc1; python_version<="3.9"
+tensorflow==2.8.0rc1; python_version=="3.10"
 tqdm==4.62.2
 xarray==0.20.1
 utilix==0.6.6

--- a/extra_requirements/requirements-tests.txt
+++ b/extra_requirements/requirements-tests.txt
@@ -23,7 +23,7 @@ keras==2.8.0rc1; python_version=="3.10"         # Tensorflow dependency
 matplotlib==3.5.1
 multihist==0.6.5
 nestpy==1.5.0; python_version<="3.9"
-git+https://github.com/NESTCollaboration/nestpy.git; python_version=="3.10"
+# git+https://github.com/NESTCollaboration/nestpy.git; python_version=="3.10"
 npshmex==0.2.1                                  # Strax dependency
 numba==0.55.1                                   # Strax dependency
 numpy==1.21.5

--- a/extra_requirements/requirements-tests.txt
+++ b/extra_requirements/requirements-tests.txt
@@ -20,6 +20,8 @@ hypothesis==6.36.1
 jupyter-client==7.1.2                          # for ipywidgets
 matplotlib==3.5.1
 multihist==0.6.4
+nestpy==1.5.0; python_version<="3.9"
+git+https://github.com/NESTCollaboration/nestpy.git; python_version=="3.10"
 npshmex==0.2.1                                  # Strax dependency
 numba==0.55.1                                   # Strax dependency
 numpy==1.21.5

--- a/extra_requirements/requirements-tests.txt
+++ b/extra_requirements/requirements-tests.txt
@@ -1,6 +1,6 @@
 # Test compatibility with these most often:
-strax==1.1.5
-straxen==1.2.6
+strax==1.1.6
+straxen==1.2.7
 
 # File for the requirements of straxen with the automated tests
 awkward==1.7.0

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setuptools.setup(
                               'flake8',
                               'pytest-cov',
                               ],
-    python_requires=">=3.6",
+    python_requires=">=3.8",
     extras_require={
         'docs': [
             'sphinx',
@@ -44,8 +44,6 @@ setuptools.setup(
         'Development Status :: 5 - Production/Stable',
         'License :: OSI Approved :: BSD License',
         'Natural Language :: English',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Intended Audience :: Science/Research',

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ setuptools.setup(
         'Natural Language :: English',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Intended Audience :: Science/Research',
         'Programming Language :: Python :: Implementation :: CPython',
         'Topic :: Scientific/Engineering :: Physics'],


### PR DESCRIPTION
Follow AxFoundation/strax#636, XENONnT/straxen#906, let's drop support for older python versions.

For nestpy, see the discussion in https://github.com/NESTCollaboration/nestpy/pull/80
Also see https://github.com/NESTCollaboration/nestpy/pull/80