### PR TITLE
PMT afterpulse not sorted by channel

### DIFF
--- a/wfsim/core/afterpulse.py
+++ b/wfsim/core/afterpulse.py
@@ -230,7 +230,8 @@ class PMT_Afterpulse(Pulse):
             _photon_amplitude = np.hstack(_photon_amplitude)
             _photon_gains = np.array(config['gains'])[_photon_channels] * _photon_amplitude
 
-            return _photon_timings, _photon_channels, _photon_gains
+            sorted_index = np.argsort(_photon_channels)
+            return _photon_timings[sorted_index], _photon_channels[sorted_index], _photon_gains[sorted_index]
 
         else:
             return np.zeros(0, np.int64), np.zeros(0, np.int64), np.zeros(0)


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
One of the optimizations in #15 on the `pulse` class created this bug, that PMT afterpulse are ordered in channel number instead of from the channel created them.

https://github.com/XENONnT/WFSim/blob/c50a7a2b7c67b37755e1d073683f902c9424f111/wfsim/core/pulse.py#L67

To resolve this, the returned values need to be sorted by the channel numbers.