### PR TITLE
Double PMT ap probability for photons emitting double PE.

### DIFF
--- a/wfsim/core/afterpulse.py
+++ b/wfsim/core/afterpulse.py
@@ -194,7 +194,7 @@ class PMT_Afterpulse(Pulse):
                 log.warning(f'PMT after pulse probability is {prob} larger than 0.5?')
 
             # Double the probability for those photon emitting dpe
-            cdf_max[signal_pulse._photon_is_dpe] *= 2
+            rU0[signal_pulse._photon_is_dpe] /= 2
 
             sel_photon_id = np.where(rU0 <= cdf_max * config['pmt_ap_modifier'])[0]
             if len(sel_photon_id) == 0:

--- a/wfsim/core/afterpulse.py
+++ b/wfsim/core/afterpulse.py
@@ -189,6 +189,13 @@ class PMT_Afterpulse(Pulse):
 
             # Select those photons with U <= max of cdf of specific channel
             cdf_max = delaytime_cdf[signal_pulse._photon_channels, -1]
+            if cdf_max.max() * config['pmt_ap_modifier'] > 0.5:
+                prob = cdf_max.max() * config['pmt_ap_modifier']
+                log.warning(f'PMT after pulse probability is {prob} larger than 0.5?')
+
+            # Double the probability for those photon emitting dpe
+            cdf_max[signal_pulse._photon_emit_dpe] *= 2
+
             sel_photon_id = np.where(rU0 <= cdf_max * config['pmt_ap_modifier'])[0]
             if len(sel_photon_id) == 0:
                 continue

--- a/wfsim/core/afterpulse.py
+++ b/wfsim/core/afterpulse.py
@@ -194,7 +194,7 @@ class PMT_Afterpulse(Pulse):
                 log.warning(f'PMT after pulse probability is {prob} larger than 0.5?')
 
             # Double the probability for those photon emitting dpe
-            cdf_max[signal_pulse._photon_emit_dpe] *= 2
+            cdf_max[signal_pulse._cur_dpe_bool] *= 2
 
             sel_photon_id = np.where(rU0 <= cdf_max * config['pmt_ap_modifier'])[0]
             if len(sel_photon_id) == 0:

--- a/wfsim/core/afterpulse.py
+++ b/wfsim/core/afterpulse.py
@@ -187,16 +187,20 @@ class PMT_Afterpulse(Pulse):
             # Assign each photon FRIST random uniform number rU0 from (0, 1] for timing
             rU0 = 1 - np.random.rand(len(signal_pulse._photon_timings))
 
-            # Select those photons with U <= max of cdf of specific channel
-            cdf_max = delaytime_cdf[signal_pulse._photon_channels, -1]
-            if cdf_max.max() * config['pmt_ap_modifier'] > 0.5:
-                prob = cdf_max.max() * config['pmt_ap_modifier']
+            # delaytime_cdf is intentionally not normalized to 1 but the probability of the AP 
+            prob_ap = delaytime_cdf[signal_pulse._photon_channels, -1]
+            if prob_ap.max() * config['pmt_ap_modifier'] > 0.5:
+                prob = prob_ap.max() * config['pmt_ap_modifier']
                 log.warning(f'PMT after pulse probability is {prob} larger than 0.5?')
+
+            # Scaling down (up) rU0 effectivly increase (decrease) the ap rate
+            rU0 /= config['pmt_ap_modifier']
 
             # Double the probability for those photon emitting dpe
             rU0[signal_pulse._photon_is_dpe] /= 2
 
-            sel_photon_id = np.where(rU0 <= cdf_max * config['pmt_ap_modifier'])[0]
+            # Select those photons with U <= max of cdf of specific channel
+            sel_photon_id = np.where(rU0 <= prob_ap)[0]
             if len(sel_photon_id) == 0:
                 continue
             sel_photon_channel = signal_pulse._photon_channels[sel_photon_id]
@@ -216,6 +220,7 @@ class PMT_Afterpulse(Pulse):
                         delaytime_cdf[sel_photon_channel]
                         - rU0[sel_photon_id][:, None]), axis=-1) * delaytime_bin_size
                             - config['pmt_ap_t_modifier'])
+                print(len(delaytime_cdf) )
                 if len(amplitude_cdf.shape) == 2:
                     ap_amplitude = np.argmin(
                         np.abs(

--- a/wfsim/core/afterpulse.py
+++ b/wfsim/core/afterpulse.py
@@ -220,7 +220,6 @@ class PMT_Afterpulse(Pulse):
                         delaytime_cdf[sel_photon_channel]
                         - rU0[sel_photon_id][:, None]), axis=-1) * delaytime_bin_size
                             - config['pmt_ap_t_modifier'])
-                print(len(delaytime_cdf) )
                 if len(amplitude_cdf.shape) == 2:
                     ap_amplitude = np.argmin(
                         np.abs(

--- a/wfsim/core/afterpulse.py
+++ b/wfsim/core/afterpulse.py
@@ -194,7 +194,7 @@ class PMT_Afterpulse(Pulse):
                 log.warning(f'PMT after pulse probability is {prob} larger than 0.5?')
 
             # Double the probability for those photon emitting dpe
-            cdf_max[signal_pulse._cur_dpe_bool] *= 2
+            cdf_max[signal_pulse._photon_is_dpe] *= 2
 
             sel_photon_id = np.where(rU0 <= cdf_max * config['pmt_ap_modifier'])[0]
             if len(sel_photon_id) == 0:

--- a/wfsim/core/pulse.py
+++ b/wfsim/core/pulse.py
@@ -62,6 +62,7 @@ class Pulse(object):
         self._n_pe_trigger = self._n_pe_trigger_bottom = 0
         self._raw_area = self._raw_area_bottom = 0
         self._raw_area_trigger = self._raw_area_trigger_bottom = 0
+        self._photon_emit_dpe = np.zeros(len(self._photon_timings), dtype=np.bool_)  # For PMT afterpulse
 
         counts_start = 0  # Secondary loop index for assigning channel
         for channel, counts in zip(*np.unique(self._photon_channels, return_counts=True)):
@@ -86,6 +87,8 @@ class Pulse(object):
 
                 _channel_photon_gains[:n_double_pe] += self.config['gains'][channel] \
                     * self.uniform_to_pe_arr(np.random.random(n_double_pe), channel)
+
+                self._photon_emit_dpe[counts_start: counts_start+n_double_pe] = True
 
             else:
                 n_double_pe = 0

--- a/wfsim/core/pulse.py
+++ b/wfsim/core/pulse.py
@@ -65,7 +65,7 @@ class Pulse(object):
 
         # Assign DPE, and save it for compute after-pulses
         p_dpe = self.config['p_double_pe_emision']
-        self._cur_dpe_bool = np.random.binomial(n=1,
+        self._photon_is_dpe = np.random.binomial(n=1,
                                                 p=p_dpe,
                                                 size=len(self._photon_timings)).astype(np.bool_)
 
@@ -74,7 +74,7 @@ class Pulse(object):
 
             # Use 'counts' amount of photon for this channel
             _channel_photon_timings = self._photon_timings[counts_start:counts_start+counts]
-            _channel_cur_dpe_bool = self._cur_dpe_bool[counts_start:counts_start+counts]
+            _channel_photon_is_dpe = self._photon_is_dpe[counts_start:counts_start+counts]
 
             counts_start += counts
             if channel in self.config['turned_off_pmts']:
@@ -89,8 +89,8 @@ class Pulse(object):
                     * self.uniform_to_pe_arr(np.random.random(len(_channel_photon_timings)), channel)
 
                 # Add some double photoelectron emission by adding another sampled gain
-                n_double_pe = _channel_cur_dpe_bool.sum()
-                _channel_photon_gains[_channel_cur_dpe_bool] += self.config['gains'][channel] \
+                n_double_pe = _channel_photon_is_dpe.sum()
+                _channel_photon_gains[_channel_photon_is_dpe] += self.config['gains'][channel] \
                     * self.uniform_to_pe_arr(np.random.random(n_double_pe), channel)
 
             else:


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
The double photo-electron in PMTs also contributes to generating PMT afterpulse, in this pr, we store a boolean array noting photons emitting dpe, in the last step of generating S1s and S2s. While we double the PMT AP probability for those photons when generating PMT afterpulses.