### PR TITLE
Change default compressor

### DIFF
--- a/wfsim/strax_interface.py
+++ b/wfsim/strax_interface.py
@@ -474,6 +474,7 @@ class ChunkRawRecords(object):
                       "generation of the instructions"),
 )
 class SimulatorPlugin(strax.Plugin):
+    compressor = 'zstd'
     depends_on = tuple()
 
     # Cannot arbitrarily rechunk records inside events


### PR DESCRIPTION
I just noticed - to my surprise - that blosc is still the default compressor, whereas  we can be about ~2x squeezer than that at almost no performance loss:
https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenonnt:ivyli:lossless_compression