### PR TITLE
Off by one in noise

### DIFF
--- a/wfsim/core/rawdata.py
+++ b/wfsim/core/rawdata.py
@@ -402,9 +402,13 @@ class RawData(object):
         right = np.max(channel_mask['right'][channel_mask['mask']])
 
         if noise_data_length-right+left-1 < 0:
-            ix_rand = np.random.randint(low=0, high=noise_data_length-1)
+            high = noise_data_length-1
         else:
-            ix_rand = np.random.randint(low=0, high=noise_data_length-right+left-1)
+            high = noise_data_length-right+left-1
+        if high <= 0:
+            ix_rand = 0
+        else:
+            ix_rand = np.random.randint(low=0, high=high)
 
         for ch in range(data.shape[0]):
             # In case adding noise to he channels is not supported


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
I just ran into this error 
```Traceback (most recent call last):
  File "/cvmfs/xenon.opensciencegrid.org/releases/nT/2022.04.2/anaconda/envs/XENONnT_2022.04.2/bin/pema_straxer", line 273, in <module>
    sys.exit(main(args))
  File "/cvmfs/xenon.opensciencegrid.org/releases/nT/2022.04.2/anaconda/envs/XENONnT_2022.04.2/bin/pema_straxer", line 193, in main
    for i, d in enumerate(get_results(run_id, target)):
  File "/cvmfs/xenon.opensciencegrid.org/releases/nT/2022.04.2/anaconda/envs/XENONnT_2022.04.2/bin/pema_straxer", line 181, in get_results
    yield from st.get_iter(**kwargs)
  File "/cvmfs/xenon.opensciencegrid.org/releases/nT/2022.04.2/anaconda/envs/XENONnT_2022.04.2/lib/python3.8/site-packages/strax/context.py", line 1321, in get_iter
    generator.throw(e)
  File "/cvmfs/xenon.opensciencegrid.org/releases/nT/2022.04.2/anaconda/envs/XENONnT_2022.04.2/lib/python3.8/site-packages/strax/context.py", line 1293, in get_iter
    for n_chunks, result in enumerate(strax.continuity_check(generator), 1):
  File "/cvmfs/xenon.opensciencegrid.org/releases/nT/2022.04.2/anaconda/envs/XENONnT_2022.04.2/lib/python3.8/site-packages/strax/chunk.py", line 303, in continuity_check
    for chunk in chunk_iter:
  File "/cvmfs/xenon.opensciencegrid.org/releases/nT/2022.04.2/anaconda/envs/XENONnT_2022.04.2/lib/python3.8/site-packages/strax/processor.py", line 302, in iter
    raise exc.with_traceback(traceback)
  File "/cvmfs/xenon.opensciencegrid.org/releases/nT/2022.04.2/anaconda/envs/XENONnT_2022.04.2/lib/python3.8/site-packages/strax/mailbox.py", line 281, in _send_from
    x = next(iterable)
  File "/cvmfs/xenon.opensciencegrid.org/releases/nT/2022.04.2/anaconda/envs/XENONnT_2022.04.2/lib/python3.8/site-packages/strax/plugin.py", line 459, in iter
    yield self.do_compute(chunk_i=chunk_i, **inputs_merged)
  File "/cvmfs/xenon.opensciencegrid.org/releases/nT/2022.04.2/anaconda/envs/XENONnT_2022.04.2/lib/python3.8/site-packages/strax/plugin.py", line 567, in do_compute
    result = self.compute(**kwargs)
  File "/cvmfs/xenon.opensciencegrid.org/releases/nT/2022.04.2/anaconda/envs/XENONnT_2022.04.2/lib/python3.8/site-packages/wfsim/strax_interface.py", line 628, in compute
    result = next(self.sim_iter)
  File "/cvmfs/xenon.opensciencegrid.org/releases/nT/2022.04.2/anaconda/envs/XENONnT_2022.04.2/lib/python3.8/site-packages/wfsim/strax_interface.py", line 331, in __call__
    for channel, left, right, data in self.rawdata(instructions=instructions,
  File "/cvmfs/xenon.opensciencegrid.org/releases/nT/2022.04.2/anaconda/envs/XENONnT_2022.04.2/lib/python3.8/site-packages/wfsim/core/rawdata.py", line 149, in __call__
    self.digitize_pulse_cache()  # from pulse cache to raw data
  File "/cvmfs/xenon.opensciencegrid.org/releases/nT/2022.04.2/anaconda/envs/XENONnT_2022.04.2/lib/python3.8/site-packages/wfsim/core/rawdata.py", line 264, in digitize_pulse_cache
    self.add_noise(data=self._raw_data,
ValueError: empty range for randrange()
```

Looking at the code I think something like this must be happening:

```python
import numba
import numpy as np

@numba.njit
def error_old(noise_data_length, right, left):
    if noise_data_length-right+left-1 < 0:
        ix_rand = np.random.randint(low=0, high=noise_data_length-1)
    else:
        ix_rand = np.random.randint(low=0, high=noise_data_length-right+left-1)
    return ix_rand
error_old(1,0,0)
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
Input In [57], in <cell line: 11>()
      9         ix_rand = np.random.randint(low=0, high=noise_data_length-right+left-1)
     10     return ix_rand
---> 11 error_old(1,0,0)

ValueError: empty range for randrange()

```

If I'm not wrong, we could just fix this by giving a zero if we are on such an edge case:
```python
import numba
import numpy as np

@numba.njit
def code_new(noise_data_length, right, left):
    if noise_data_length-right+left-1 < 0:
        high = noise_data_length-1
    else:
        high = noise_data_length-right+left-1
    if high <= 0:
        ix_rand = 0
    else:
        ix_rand = np.random.randint(low=0, high=high)
    return ix_rand
code_new(1,0,0)
---------------------------------------------------------------------------
0
```
