### PR TITLE
Fix broken tests

### DIFF
--- a/extra_requirements/requirements-tests.txt
+++ b/extra_requirements/requirements-tests.txt
@@ -1,3 +1,4 @@
 strax==1.2.2
 straxen==1.7.1
+epix==0.3.0
 git+https://github.com/XENONnT/ax_env

--- a/tests/test_wfsim.py
+++ b/tests/test_wfsim.py
@@ -162,7 +162,7 @@ def test_sim_mc_chain():
 
         epix_config = {'cut_by_eventid': True, 'debug': True, 'source_rate': 0, 'micro_separation_time': 10.,
                        'max_delay': 1e7, 'detector_config_override': None, 'micro_separation': 0.05,
-                       'tag_cluster_by': 'time'}
+                       'tag_cluster_by': 'time', 'nr_only': False}
 
         st.register(wfsim.RawRecordsFromMcChain)
         st.set_config(dict(


### PR DESCRIPTION
Seems like https://github.com/XENONnT/epix/pull/53 requires a new key not included in the tests - I'm a bit surprised this only now shows up.