### PR TITLE
Fix R outside due to float32 rounding

### DIFF
--- a/wfsim/strax_interface.py
+++ b/wfsim/strax_interface.py
@@ -677,8 +677,9 @@ class RawRecordsFromFaxNT(SimulatorPlugin):
         # Let below cathode S1 instructions pass but remove S2 instructions
         m = (self.instructions['z'] < - self.config['tpc_length']) & (self.instructions['type'] == 2)
         self.instructions = self.instructions[~m]
+        r_instr = np.sqrt(self.instructions['x']**2 + self.instructions['y']**2)
 
-        assert np.all(self.instructions['x']**2 + self.instructions['y']**2 < self.config['tpc_radius']**2), \
+        assert np.all((r_instr<self.config['tpc_radius'])|np.isclose(r_instr,self.config['tpc_radius'])), \
             "Interaction is outside the TPC (radius)"
         assert np.all(self.instructions['z'] < 0.25), \
             "Interaction is outside the TPC (in Z)"


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**

Fix for bug where instructions are flagged outside of the TPC due to the float32 rounding. Fixes https://github.com/XENONnT/WFSim/issues/384