### PR TITLE
Deprecate the usage of `XENONnT/ax_env`

### DIFF
--- a/extra_requirements/requirements-tests.txt
+++ b/extra_requirements/requirements-tests.txt
@@ -1,4 +1,4 @@
 strax>=1.6.0
 straxen>=2.2.0
 epix>=0.3.6
-git+https://github.com/XENONnT/ax_env
+git+https://github.com/XENONnT/base_environment


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**

Use base_environment for pytest, following https://github.com/XENONnT/base_environment/pull/1487.

**WFSim needs you:**
 - Please add a test for this PR, as a bare minimum, make sure it's covered in coveralls!
 - Can you add a docsting to all your functions?

*Pay attention:*
 - Due to databases being needed for testing, making a PR from your own fork will typically NOT run the tests. If you then merge master might break
